### PR TITLE
fix(schema/redshift): serve the table and view definitions GetSchemaString asks for

### DIFF
--- a/backend/plugin/schema/redshift/get_database_definition.go
+++ b/backend/plugin/schema/redshift/get_database_definition.go
@@ -16,19 +16,18 @@ func init() {
 }
 
 // GetTableDefinition renders one table exactly as the whole-database output
-// renders it, minus the section banner. The schema argument is unused: the
-// writers emit the name the metadata carries.
-func GetTableDefinition(_ string, table *storepb.TableMetadata, _ []*storepb.SequenceMetadata) (string, error) {
+// renders it, minus the section banner.
+func GetTableDefinition(schemaName string, table *storepb.TableMetadata, _ []*storepb.SequenceMetadata) (string, error) {
 	var sb strings.Builder
-	if err := writeTable(&sb, convertToTableState(0, table)); err != nil {
+	if err := writeTable(&sb, convertToTableState(0, schemaName, table)); err != nil {
 		return "", err
 	}
 	return sb.String(), nil
 }
 
-func GetViewDefinition(_ string, view *storepb.ViewMetadata) (string, error) {
+func GetViewDefinition(schemaName string, view *storepb.ViewMetadata) (string, error) {
 	var sb strings.Builder
-	if err := writeView(&sb, convertToViewState(0, view)); err != nil {
+	if err := writeView(&sb, convertToViewState(0, schemaName, view)); err != nil {
 		return "", err
 	}
 	return sb.String(), nil
@@ -113,7 +112,7 @@ func writeTable(w io.StringWriter, table *tableState) error {
 		return err
 	}
 	if table.comment != "" {
-		if _, err := fmt.Fprintf(buf, "COMMENT ON TABLE %s IS '%s';\n", table.name, table.comment); err != nil {
+		if _, err := fmt.Fprintf(buf, "COMMENT ON TABLE %s IS '%s';\n", table.qualifiedName(), escapeSingleQuote(table.comment)); err != nil {
 			return err
 		}
 	}
@@ -121,7 +120,7 @@ func writeTable(w io.StringWriter, table *tableState) error {
 		if column.comment == "" {
 			continue
 		}
-		if _, err := fmt.Fprintf(buf, "COMMENT ON COLUMN %s.%s IS '%s';\n", table.name, column.name, column.comment); err != nil {
+		if _, err := fmt.Fprintf(buf, "COMMENT ON COLUMN %s.%s IS '%s';\n", table.qualifiedName(), column.name, escapeSingleQuote(column.comment)); err != nil {
 			return err
 		}
 	}
@@ -136,7 +135,7 @@ func writeView(w io.StringWriter, view *viewState) error {
 		return err
 	}
 	if view.comment != "" {
-		if _, err := fmt.Fprintf(buf, "COMMENT ON VIEW %s IS '%s';\n", view.name, view.comment); err != nil {
+		if _, err := fmt.Fprintf(buf, "COMMENT ON VIEW %s IS '%s';\n", view.qualifiedName(), escapeSingleQuote(view.comment)); err != nil {
 			return err
 		}
 	}

--- a/backend/plugin/schema/redshift/get_database_definition.go
+++ b/backend/plugin/schema/redshift/get_database_definition.go
@@ -120,7 +120,7 @@ func writeTable(w io.StringWriter, table *tableState) error {
 		if column.comment == "" {
 			continue
 		}
-		if _, err := fmt.Fprintf(buf, "COMMENT ON COLUMN %s.%s IS '%s';\n", table.qualifiedName(), column.name, escapeSingleQuote(column.comment)); err != nil {
+		if _, err := fmt.Fprintf(buf, "COMMENT ON COLUMN %s.%s IS '%s';\n", table.qualifiedName(), quoteIdentifier(column.name), escapeSingleQuote(column.comment)); err != nil {
 			return err
 		}
 	}

--- a/backend/plugin/schema/redshift/get_database_definition.go
+++ b/backend/plugin/schema/redshift/get_database_definition.go
@@ -11,6 +11,27 @@ import (
 
 func init() {
 	schema.RegisterGetDatabaseDefinition(storepb.Engine_REDSHIFT, GetDatabaseDefinition)
+	schema.RegisterGetTableDefinition(storepb.Engine_REDSHIFT, GetTableDefinition)
+	schema.RegisterGetViewDefinition(storepb.Engine_REDSHIFT, GetViewDefinition)
+}
+
+// GetTableDefinition renders one table exactly as the whole-database output
+// renders it, minus the section banner. The schema argument is unused: the
+// writers emit the name the metadata carries.
+func GetTableDefinition(_ string, table *storepb.TableMetadata, _ []*storepb.SequenceMetadata) (string, error) {
+	var sb strings.Builder
+	if err := writeTable(&sb, convertToTableState(0, table)); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+func GetViewDefinition(_ string, view *storepb.ViewMetadata) (string, error) {
+	var sb strings.Builder
+	if err := writeView(&sb, convertToViewState(0, view)); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
 }
 
 func GetDatabaseDefinition(_ schema.GetDefinitionContext, to *storepb.DatabaseSchemaMetadata) (string, error) {
@@ -48,24 +69,7 @@ func writeTables(w io.StringWriter, to *storepb.DatabaseSchemaMetadata, state *d
 				return err
 			}
 
-			buf := &strings.Builder{}
-			if err := table.toString(buf); err != nil {
-				return err
-			}
-			// Generate comment for table and columns.
-			if table.comment != "" {
-				if _, err := fmt.Fprintf(buf, "COMMENT ON TABLE %s IS '%s';\n", table.name, table.comment); err != nil {
-					return err
-				}
-			}
-			for _, column := range table.columns {
-				if column.comment != "" {
-					if _, err := fmt.Fprintf(buf, "COMMENT ON COLUMN %s.%s IS '%s';\n", table.name, column.name, column.comment); err != nil {
-						return err
-					}
-				}
-			}
-			if _, err := w.WriteString(buf.String()); err != nil {
+			if err := writeTable(w, table); err != nil {
 				return err
 			}
 			delete(schemaState.tables, table.name)
@@ -91,23 +95,53 @@ func writeViews(w io.StringWriter, to *storepb.DatabaseSchemaMetadata, state *da
 				return err
 			}
 
-			buf := &strings.Builder{}
-			if err := view.toString(buf); err != nil {
-				return err
-			}
-			// Generate comment for view.
-			if view.comment != "" {
-				if _, err := fmt.Fprintf(buf, "COMMENT ON VIEW %s IS '%s';\n", view.name, view.comment); err != nil {
-					return err
-				}
-			}
-			if _, err := w.WriteString(buf.String()); err != nil {
+			if err := writeView(w, view); err != nil {
 				return err
 			}
 			delete(schemaState.views, view.name)
 		}
 	}
 	return nil
+}
+
+// writeTable writes one table and the comments that belong to it. Column
+// comments follow the column order the CREATE TABLE body uses; ranging over the
+// map directly, as this did before, ordered them differently run to run.
+func writeTable(w io.StringWriter, table *tableState) error {
+	buf := &strings.Builder{}
+	if err := table.toString(buf); err != nil {
+		return err
+	}
+	if table.comment != "" {
+		if _, err := fmt.Fprintf(buf, "COMMENT ON TABLE %s IS '%s';\n", table.name, table.comment); err != nil {
+			return err
+		}
+	}
+	for _, column := range sortedColumns(table.columns) {
+		if column.comment == "" {
+			continue
+		}
+		if _, err := fmt.Fprintf(buf, "COMMENT ON COLUMN %s.%s IS '%s';\n", table.name, column.name, column.comment); err != nil {
+			return err
+		}
+	}
+	_, err := w.WriteString(buf.String())
+	return err
+}
+
+// writeView writes one view and its comment.
+func writeView(w io.StringWriter, view *viewState) error {
+	buf := &strings.Builder{}
+	if err := view.toString(buf); err != nil {
+		return err
+	}
+	if view.comment != "" {
+		if _, err := fmt.Fprintf(buf, "COMMENT ON VIEW %s IS '%s';\n", view.name, view.comment); err != nil {
+			return err
+		}
+	}
+	_, err := w.WriteString(buf.String())
+	return err
 }
 
 func getTableAnnouncement(name string) string {

--- a/backend/plugin/schema/redshift/get_database_definition_test.go
+++ b/backend/plugin/schema/redshift/get_database_definition_test.go
@@ -204,3 +204,29 @@ CREATE OR REPLACE VIEW public.recent_orders AS SELECT id FROM orders;
 	require.NoError(t, err)
 	require.Contains(t, got, table)
 }
+
+// TestForeignKeyKeepsReferencedSchema pins the qualifier on the REFERENCES
+// target. The Redshift sync strips it off ReferencedTable and keeps it in
+// ReferencedSchema, so dropping it binds the constraint to whatever the search
+// path resolves instead of the table the metadata names.
+func TestForeignKeyKeepsReferencedSchema(t *testing.T) {
+	got, err := GetTableDefinition("analytics", &storepb.TableMetadata{
+		Name: "child",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "id", Type: "integer"},
+			{Name: "parent_id", Type: "integer", Nullable: true},
+		},
+		ForeignKeys: []*storepb.ForeignKeyMetadata{
+			{
+				Name:              "child_parent_fk",
+				Columns:           []string{"parent_id"},
+				ReferencedSchema:  "warehouse",
+				ReferencedTable:   "parent",
+				ReferencedColumns: []string{"id"},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Contains(t, got, "REFERENCES warehouse.parent(id)")
+	require.NotContains(t, got, "REFERENCES parent(id)")
+}

--- a/backend/plugin/schema/redshift/get_database_definition_test.go
+++ b/backend/plugin/schema/redshift/get_database_definition_test.go
@@ -29,14 +29,14 @@ func TestGetObjectDefinition(t *testing.T) {
 					},
 				}, nil)
 			},
-			want: `CREATE TABLE public.orders (
-  id integer NOT NULL,
-  total numeric(10,2),
-  label character varying(50)
+			want: `CREATE TABLE "public"."orders" (
+  "id" integer NOT NULL,
+  "total" numeric(10,2),
+  "label" character varying(50)
 );
-COMMENT ON TABLE public.orders IS 'one row per order';
-COMMENT ON COLUMN public.orders.id IS 'surrogate key';
-COMMENT ON COLUMN public.orders.label IS 'display name';
+COMMENT ON TABLE "public"."orders" IS 'one row per order';
+COMMENT ON COLUMN "public"."orders"."id" IS 'surrogate key';
+COMMENT ON COLUMN "public"."orders"."label" IS 'display name';
 `,
 		},
 		{
@@ -48,8 +48,8 @@ COMMENT ON COLUMN public.orders.label IS 'display name';
 					Comment:    "last 30 days",
 				})
 			},
-			want: `CREATE OR REPLACE VIEW public.recent_orders AS SELECT id, total FROM orders;
-COMMENT ON VIEW public.recent_orders IS 'last 30 days';
+			want: `CREATE OR REPLACE VIEW "public"."recent_orders" AS SELECT id, total FROM orders;
+COMMENT ON VIEW "public"."recent_orders" IS 'last 30 days';
 `,
 		},
 		{
@@ -62,8 +62,8 @@ COMMENT ON VIEW public.recent_orders IS 'last 30 days';
 					Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
 				}, nil)
 			},
-			want: `CREATE TABLE analytics.orders (
-  id integer NOT NULL
+			want: `CREATE TABLE "analytics"."orders" (
+  "id" integer NOT NULL
 );
 `,
 		},
@@ -78,11 +78,11 @@ COMMENT ON VIEW public.recent_orders IS 'last 30 days';
 					Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer", Comment: "don't drop"}},
 				}, nil)
 			},
-			want: `CREATE TABLE public.orders (
-  id integer NOT NULL
+			want: `CREATE TABLE "public"."orders" (
+  "id" integer NOT NULL
 );
-COMMENT ON TABLE public.orders IS 'owner''s orders';
-COMMENT ON COLUMN public.orders.id IS 'don''t drop';
+COMMENT ON TABLE "public"."orders" IS 'owner''s orders';
+COMMENT ON COLUMN "public"."orders"."id" IS 'don''t drop';
 `,
 		},
 	}
@@ -188,16 +188,16 @@ func TestGetDatabaseDefinitionKeepsSections(t *testing.T) {
 	require.Equal(t, `--
 -- Table structure for `+"`orders`"+`
 --
-CREATE TABLE public.orders (
-  id integer NOT NULL
+CREATE TABLE "public"."orders" (
+  "id" integer NOT NULL
 );
-COMMENT ON TABLE public.orders IS 'one row per order';
-COMMENT ON COLUMN public.orders.id IS 'surrogate key';
+COMMENT ON TABLE "public"."orders" IS 'one row per order';
+COMMENT ON COLUMN "public"."orders"."id" IS 'surrogate key';
 
 --
 -- View structure for `+"`recent_orders`"+`
 --
-CREATE OR REPLACE VIEW public.recent_orders AS SELECT id FROM orders;
+CREATE OR REPLACE VIEW "public"."recent_orders" AS SELECT id FROM orders;
 `, got)
 
 	table, err := GetTableDefinition("public", metadata.Schemas[0].Tables[0], nil)
@@ -227,6 +227,24 @@ func TestForeignKeyKeepsReferencedSchema(t *testing.T) {
 		},
 	}, nil)
 	require.NoError(t, err)
-	require.Contains(t, got, "REFERENCES warehouse.parent(id)")
-	require.NotContains(t, got, "REFERENCES parent(id)")
+	require.Contains(t, got, `REFERENCES "warehouse"."parent"("id")`)
+	require.NotContains(t, got, `REFERENCES "parent"("id")`)
+}
+
+// TestIdentifiersNeedingQuotesSurvive covers the names that unquoted output
+// would corrupt: Redshift folds an unquoted identifier to lower case and rejects
+// one containing a space, and an embedded double quote has to be doubled.
+func TestIdentifiersNeedingQuotesSurvive(t *testing.T) {
+	got, err := GetTableDefinition("Sales Data", &storepb.TableMetadata{
+		Name: "MixedCase",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: `od"d`, Type: "integer", Comment: "quoted name"},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, `CREATE TABLE "Sales Data"."MixedCase" (
+  "od""d" integer NOT NULL
+);
+COMMENT ON COLUMN "Sales Data"."MixedCase"."od""d" IS 'quoted name';
+`, got)
 }

--- a/backend/plugin/schema/redshift/get_database_definition_test.go
+++ b/backend/plugin/schema/redshift/get_database_definition_test.go
@@ -248,3 +248,36 @@ func TestIdentifiersNeedingQuotesSurvive(t *testing.T) {
 COMMENT ON COLUMN "Sales Data"."MixedCase"."od""d" IS 'quoted name';
 `, got)
 }
+
+// TestIndexKeysAreVerbatimAndForeignKeyColumnsAreQuoted pins the split between
+// the two: index expressions arrive from pg_get_indexdef(.., true) already
+// quoted, while getColumnList strips the quotes off foreign key columns, so one
+// must be written as-is and the other must be quoted.
+func TestIndexKeysAreVerbatimAndForeignKeyColumnsAreQuoted(t *testing.T) {
+	got, err := GetTableDefinition("public", &storepb.TableMetadata{
+		Name: "t",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "MixedCase", Type: "integer"},
+			{Name: "parent_id", Type: "integer", Nullable: true},
+		},
+		Indexes: []*storepb.IndexMetadata{
+			{Name: "t_pkey", Primary: true, Expressions: []string{`"MixedCase"`}},
+		},
+		ForeignKeys: []*storepb.ForeignKeyMetadata{
+			{
+				Name:              "t_parent_fk",
+				Columns:           []string{"parent_id"},
+				ReferencedSchema:  "public",
+				ReferencedTable:   "parent",
+				ReferencedColumns: []string{"id"},
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	// The canonical expression passes through untouched, not re-quoted.
+	require.Contains(t, got, `PRIMARY KEY ("MixedCase")`)
+	require.NotContains(t, got, `"""MixedCase"""`)
+	// Foreign key columns arrive bare and are quoted here.
+	require.Contains(t, got, `FOREIGN KEY ("parent_id") REFERENCES "public"."parent"("id")`)
+}

--- a/backend/plugin/schema/redshift/get_database_definition_test.go
+++ b/backend/plugin/schema/redshift/get_database_definition_test.go
@@ -29,14 +29,14 @@ func TestGetObjectDefinition(t *testing.T) {
 					},
 				}, nil)
 			},
-			want: `CREATE TABLE orders (
+			want: `CREATE TABLE public.orders (
   id integer NOT NULL,
   total numeric(10,2),
   label character varying(50)
 );
-COMMENT ON TABLE orders IS 'one row per order';
-COMMENT ON COLUMN orders.id IS 'surrogate key';
-COMMENT ON COLUMN orders.label IS 'display name';
+COMMENT ON TABLE public.orders IS 'one row per order';
+COMMENT ON COLUMN public.orders.id IS 'surrogate key';
+COMMENT ON COLUMN public.orders.label IS 'display name';
 `,
 		},
 		{
@@ -48,8 +48,41 @@ COMMENT ON COLUMN orders.label IS 'display name';
 					Comment:    "last 30 days",
 				})
 			},
-			want: `CREATE OR REPLACE VIEW recent_orders AS SELECT id, total FROM orders;
-COMMENT ON VIEW recent_orders IS 'last 30 days';
+			want: `CREATE OR REPLACE VIEW public.recent_orders AS SELECT id, total FROM orders;
+COMMENT ON VIEW public.recent_orders IS 'last 30 days';
+`,
+		},
+		{
+			// GetSchemaString passes the requested schema, and a table outside
+			// the search path has to carry it or the DDL lands somewhere else.
+			name: "table outside the default schema keeps its qualifier",
+			get: func() (string, error) {
+				return GetTableDefinition("analytics", &storepb.TableMetadata{
+					Name:    "orders",
+					Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
+				}, nil)
+			},
+			want: `CREATE TABLE analytics.orders (
+  id integer NOT NULL
+);
+`,
+		},
+		{
+			// An apostrophe would close the literal and produce DDL that will
+			// not replay.
+			name: "comments with apostrophes stay valid",
+			get: func() (string, error) {
+				return GetTableDefinition("public", &storepb.TableMetadata{
+					Name:    "orders",
+					Comment: "owner's orders",
+					Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer", Comment: "don't drop"}},
+				}, nil)
+			},
+			want: `CREATE TABLE public.orders (
+  id integer NOT NULL
+);
+COMMENT ON TABLE public.orders IS 'owner''s orders';
+COMMENT ON COLUMN public.orders.id IS 'don''t drop';
 `,
 		},
 	}
@@ -155,16 +188,16 @@ func TestGetDatabaseDefinitionKeepsSections(t *testing.T) {
 	require.Equal(t, `--
 -- Table structure for `+"`orders`"+`
 --
-CREATE TABLE orders (
+CREATE TABLE public.orders (
   id integer NOT NULL
 );
-COMMENT ON TABLE orders IS 'one row per order';
-COMMENT ON COLUMN orders.id IS 'surrogate key';
+COMMENT ON TABLE public.orders IS 'one row per order';
+COMMENT ON COLUMN public.orders.id IS 'surrogate key';
 
 --
 -- View structure for `+"`recent_orders`"+`
 --
-CREATE OR REPLACE VIEW recent_orders AS SELECT id FROM orders;
+CREATE OR REPLACE VIEW public.recent_orders AS SELECT id FROM orders;
 `, got)
 
 	table, err := GetTableDefinition("public", metadata.Schemas[0].Tables[0], nil)

--- a/backend/plugin/schema/redshift/get_database_definition_test.go
+++ b/backend/plugin/schema/redshift/get_database_definition_test.go
@@ -1,0 +1,173 @@
+package redshift
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+)
+
+func TestGetObjectDefinition(t *testing.T) {
+	tests := []struct {
+		name string
+		get  func() (string, error)
+		want string
+	}{
+		{
+			name: "table with comments",
+			get: func() (string, error) {
+				return GetTableDefinition("public", &storepb.TableMetadata{
+					Name:    "orders",
+					Comment: "one row per order",
+					Columns: []*storepb.ColumnMetadata{
+						{Name: "id", Type: "integer", Comment: "surrogate key"},
+						{Name: "total", Type: "numeric(10,2)", Nullable: true},
+						{Name: "label", Type: "character varying(50)", Nullable: true, Comment: "display name"},
+					},
+				}, nil)
+			},
+			want: `CREATE TABLE orders (
+  id integer NOT NULL,
+  total numeric(10,2),
+  label character varying(50)
+);
+COMMENT ON TABLE orders IS 'one row per order';
+COMMENT ON COLUMN orders.id IS 'surrogate key';
+COMMENT ON COLUMN orders.label IS 'display name';
+`,
+		},
+		{
+			name: "view with comment",
+			get: func() (string, error) {
+				return GetViewDefinition("public", &storepb.ViewMetadata{
+					Name:       "recent_orders",
+					Definition: "SELECT id, total FROM orders",
+					Comment:    "last 30 days",
+				})
+			},
+			want: `CREATE OR REPLACE VIEW recent_orders AS SELECT id, total FROM orders;
+COMMENT ON VIEW recent_orders IS 'last 30 days';
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.get()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestColumnCommentOrderIsStable pins the ordering of the trailing COMMENT ON
+// COLUMN statements. They used to come from ranging over a map, so the dump
+// differed between runs for any table with more than one commented column.
+func TestColumnCommentOrderIsStable(t *testing.T) {
+	table := &storepb.TableMetadata{Name: "wide"}
+	for _, name := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		table.Columns = append(table.Columns, &storepb.ColumnMetadata{
+			Name:     name,
+			Type:     "integer",
+			Nullable: true,
+			Comment:  "note " + name,
+		})
+	}
+
+	first, err := GetTableDefinition("public", table, nil)
+	require.NoError(t, err)
+	require.Equal(t, 8, strings.Count(first, "COMMENT ON COLUMN"))
+
+	for i := 0; i < 200; i++ {
+		got, err := GetTableDefinition("public", table, nil)
+		require.NoError(t, err)
+		require.Equalf(t, first, got, "column comment order changed on iteration %d", i)
+	}
+}
+
+// TestObjectDefinitionsRegisteredForRedshift goes through the schema registry
+// rather than calling the functions directly, because the registry lookup is
+// what was missing: GetSchemaString served only DATABASE for Redshift and
+// returned "engine REDSHIFT is not supported" for TABLE and VIEW, both of which
+// the SQL editor offers because supportGetStringSchema lists REDSHIFT.
+func TestObjectDefinitionsRegisteredForRedshift(t *testing.T) {
+	tests := []struct {
+		name string
+		get  func() (string, error)
+	}{
+		{
+			name: "table",
+			get: func() (string, error) {
+				return schema.GetTableDefinition(storepb.Engine_REDSHIFT, "public", &storepb.TableMetadata{
+					Name:    "t",
+					Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
+				}, nil)
+			},
+		},
+		{
+			name: "view",
+			get: func() (string, error) {
+				return schema.GetViewDefinition(storepb.Engine_REDSHIFT, "public", &storepb.ViewMetadata{
+					Name:       "v",
+					Definition: "SELECT 1",
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.get()
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+		})
+	}
+}
+
+// TestGetDatabaseDefinitionKeepsSections guards the extraction above: the
+// whole-database output still frames each object with its banner and renders
+// the same body the single-object entry points return.
+func TestGetDatabaseDefinitionKeepsSections(t *testing.T) {
+	metadata := &storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name:    "orders",
+						Comment: "one row per order",
+						Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer", Comment: "surrogate key"}},
+					},
+				},
+				Views: []*storepb.ViewMetadata{
+					{Name: "recent_orders", Definition: "SELECT id FROM orders"},
+				},
+			},
+		},
+	}
+
+	got, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, metadata)
+	require.NoError(t, err)
+
+	require.Equal(t, `--
+-- Table structure for `+"`orders`"+`
+--
+CREATE TABLE orders (
+  id integer NOT NULL
+);
+COMMENT ON TABLE orders IS 'one row per order';
+COMMENT ON COLUMN orders.id IS 'surrogate key';
+
+--
+-- View structure for `+"`recent_orders`"+`
+--
+CREATE OR REPLACE VIEW recent_orders AS SELECT id FROM orders;
+`, got)
+
+	table, err := GetTableDefinition("public", metadata.Schemas[0].Tables[0], nil)
+	require.NoError(t, err)
+	require.Contains(t, got, table)
+}

--- a/backend/plugin/schema/redshift/state.go
+++ b/backend/plugin/schema/redshift/state.go
@@ -296,7 +296,10 @@ func (i *indexState) toString(buf *strings.Builder) error {
 					return err
 				}
 			}
-			if _, err := buf.WriteString(quoteIdentifier(key)); err != nil {
+			// Written verbatim: these come from pg_get_indexdef(.., true), which
+			// already quotes what needs it and can be an expression rather than
+			// a column, so quoting again would name something else.
+			if _, err := buf.WriteString(key); err != nil {
 				return err
 			}
 		}
@@ -313,7 +316,10 @@ func (i *indexState) toString(buf *strings.Builder) error {
 					return err
 				}
 			}
-			if _, err := buf.WriteString(quoteIdentifier(key)); err != nil {
+			// Written verbatim: these come from pg_get_indexdef(.., true), which
+			// already quotes what needs it and can be an expression rather than
+			// a column, so quoting again would name something else.
+			if _, err := buf.WriteString(key); err != nil {
 				return err
 			}
 		}

--- a/backend/plugin/schema/redshift/state.go
+++ b/backend/plugin/schema/redshift/state.go
@@ -67,19 +67,7 @@ func (t *tableState) toString(buf *strings.Builder) error {
 	if _, err := fmt.Fprintf(buf, "CREATE TABLE %s (\n  ", t.name); err != nil {
 		return err
 	}
-	columns := []*columnState{}
-	for _, column := range t.columns {
-		columns = append(columns, column)
-	}
-	slices.SortFunc(columns, func(a, b *columnState) int {
-		if a.id < b.id {
-			return -1
-		}
-		if a.id > b.id {
-			return 1
-		}
-		return 0
-	})
+	columns := sortedColumns(t.columns)
 	for i, column := range columns {
 		if i > 0 {
 			if _, err := buf.WriteString(",\n  "); err != nil {
@@ -161,6 +149,26 @@ func newTableState(id int, name string) *tableState {
 		indexes:     make(map[string]*indexState),
 		foreignKeys: make(map[string]*foreignKeyState),
 	}
+}
+
+// sortedColumns returns a table's columns in declaration order. Both the
+// CREATE TABLE body and the trailing COMMENT ON COLUMN statements go through
+// it, so the two agree and neither depends on map iteration order.
+func sortedColumns(columns map[string]*columnState) []*columnState {
+	sorted := make([]*columnState, 0, len(columns))
+	for _, column := range columns {
+		sorted = append(sorted, column)
+	}
+	slices.SortFunc(sorted, func(a, b *columnState) int {
+		if a.id < b.id {
+			return -1
+		}
+		if a.id > b.id {
+			return 1
+		}
+		return 0
+	})
+	return sorted
 }
 
 func convertToTableState(id int, table *storepb.TableMetadata) *tableState {

--- a/backend/plugin/schema/redshift/state.go
+++ b/backend/plugin/schema/redshift/state.go
@@ -35,6 +35,30 @@ type schemaState struct {
 	views  map[string]*viewState
 }
 
+// qualifiedName prefixes the object with its schema, so DDL for analytics.orders
+// cannot land in public. The prefix is dropped when no schema is known, which is
+// how the single-object entry points behave when the caller passes none.
+func qualifyName(schemaName, objectName string) string {
+	if schemaName == "" {
+		return objectName
+	}
+	return schemaName + "." + objectName
+}
+
+func (t *tableState) qualifiedName() string {
+	return qualifyName(t.schema, t.name)
+}
+
+func (v *viewState) qualifiedName() string {
+	return qualifyName(v.schema, v.name)
+}
+
+// escapeSingleQuote encodes a comment for a SQL string literal; an apostrophe in
+// "owner's orders" would otherwise close the literal and produce invalid DDL.
+func escapeSingleQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
 func newSchemaState() *schemaState {
 	return &schemaState{
 		tables: make(map[string]*tableState),
@@ -46,16 +70,17 @@ func convertToSchemaState(schema *storepb.SchemaMetadata) *schemaState {
 	state := newSchemaState()
 	state.name = schema.Name
 	for i, table := range schema.Tables {
-		state.tables[table.Name] = convertToTableState(i, table)
+		state.tables[table.Name] = convertToTableState(i, schema.Name, table)
 	}
 	for i, view := range schema.Views {
-		state.views[view.Name] = convertToViewState(i, view)
+		state.views[view.Name] = convertToViewState(i, schema.Name, view)
 	}
 	return state
 }
 
 type tableState struct {
 	id          int
+	schema      string
 	name        string
 	columns     map[string]*columnState
 	indexes     map[string]*indexState
@@ -64,7 +89,7 @@ type tableState struct {
 }
 
 func (t *tableState) toString(buf *strings.Builder) error {
-	if _, err := fmt.Fprintf(buf, "CREATE TABLE %s (\n  ", t.name); err != nil {
+	if _, err := fmt.Fprintf(buf, "CREATE TABLE %s (\n  ", t.qualifiedName()); err != nil {
 		return err
 	}
 	columns := sortedColumns(t.columns)
@@ -171,8 +196,9 @@ func sortedColumns(columns map[string]*columnState) []*columnState {
 	return sorted
 }
 
-func convertToTableState(id int, table *storepb.TableMetadata) *tableState {
+func convertToTableState(id int, schemaName string, table *storepb.TableMetadata) *tableState {
 	state := newTableState(id, table.Name)
+	state.schema = schemaName
 	state.comment = table.Comment
 	for i, column := range table.Columns {
 		state.columns[column.Name] = convertToColumnState(i, column)
@@ -377,14 +403,16 @@ func isExpression(value string) bool {
 
 type viewState struct {
 	id         int
+	schema     string
 	name       string
 	definition string
 	comment    string
 }
 
-func convertToViewState(id int, view *storepb.ViewMetadata) *viewState {
+func convertToViewState(id int, schemaName string, view *storepb.ViewMetadata) *viewState {
 	return &viewState{
 		id:         id,
+		schema:     schemaName,
 		name:       view.Name,
 		definition: view.Definition,
 		comment:    view.Comment,
@@ -392,7 +420,7 @@ func convertToViewState(id int, view *storepb.ViewMetadata) *viewState {
 }
 
 func (v *viewState) toString(buf io.StringWriter) error {
-	stmt := fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s", v.name, v.definition)
+	stmt := fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s", v.qualifiedName(), v.definition)
 	if !strings.HasSuffix(stmt, ";") {
 		stmt += ";"
 	}

--- a/backend/plugin/schema/redshift/state.go
+++ b/backend/plugin/schema/redshift/state.go
@@ -216,6 +216,7 @@ type foreignKeyState struct {
 	id                int
 	name              string
 	columns           []string
+	referencedSchema  string
 	referencedTable   string
 	referencedColumns []string
 }
@@ -225,6 +226,7 @@ func convertToForeignKeyState(id int, foreignKey *storepb.ForeignKeyMetadata) *f
 		id:                id,
 		name:              foreignKey.Name,
 		columns:           foreignKey.Columns,
+		referencedSchema:  foreignKey.ReferencedSchema,
 		referencedTable:   foreignKey.ReferencedTable,
 		referencedColumns: foreignKey.ReferencedColumns,
 	}
@@ -242,7 +244,11 @@ func (f *foreignKeyState) toString(buf *strings.Builder) error {
 			return err
 		}
 		referencedColumn := f.referencedColumns[i]
-		if _, err := fmt.Fprintf(buf, "%s(%s)", f.referencedTable, referencedColumn); err != nil {
+		// The sync strips the qualifier off ReferencedTable and keeps it in
+		// ReferencedSchema, so an unqualified target here would bind to whatever
+		// the search path resolves rather than the table the constraint names.
+		referenced := qualifyName(f.referencedSchema, f.referencedTable)
+		if _, err := fmt.Fprintf(buf, "%s(%s)", referenced, referencedColumn); err != nil {
 			return err
 		}
 	}

--- a/backend/plugin/schema/redshift/state.go
+++ b/backend/plugin/schema/redshift/state.go
@@ -40,9 +40,17 @@ type schemaState struct {
 // how the single-object entry points behave when the caller passes none.
 func qualifyName(schemaName, objectName string) string {
 	if schemaName == "" {
-		return objectName
+		return quoteIdentifier(objectName)
 	}
-	return schemaName + "." + objectName
+	return quoteIdentifier(schemaName) + "." + quoteIdentifier(objectName)
+}
+
+// quoteIdentifier renders a name as a quoted SQL identifier. Redshift folds an
+// unquoted name to lower case and rejects one containing a space or a reserved
+// word outright, so a name the catalog reports verbatim has to be quoted to come
+// back as itself. An embedded double quote is doubled, as in PostgreSQL.
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func (t *tableState) qualifiedName() string {
@@ -237,7 +245,7 @@ func (f *foreignKeyState) toString(buf *strings.Builder) error {
 		if _, err := buf.WriteString("FOREIGN KEY ("); err != nil {
 			return err
 		}
-		if _, err := buf.WriteString(column); err != nil {
+		if _, err := buf.WriteString(quoteIdentifier(column)); err != nil {
 			return err
 		}
 		if _, err := buf.WriteString(") REFERENCES "); err != nil {
@@ -248,7 +256,7 @@ func (f *foreignKeyState) toString(buf *strings.Builder) error {
 		// ReferencedSchema, so an unqualified target here would bind to whatever
 		// the search path resolves rather than the table the constraint names.
 		referenced := qualifyName(f.referencedSchema, f.referencedTable)
-		if _, err := fmt.Fprintf(buf, "%s(%s)", referenced, referencedColumn); err != nil {
+		if _, err := fmt.Fprintf(buf, "%s(%s)", referenced, quoteIdentifier(referencedColumn)); err != nil {
 			return err
 		}
 	}
@@ -288,7 +296,7 @@ func (i *indexState) toString(buf *strings.Builder) error {
 					return err
 				}
 			}
-			if _, err := buf.WriteString(key); err != nil {
+			if _, err := buf.WriteString(quoteIdentifier(key)); err != nil {
 				return err
 			}
 		}
@@ -305,7 +313,7 @@ func (i *indexState) toString(buf *strings.Builder) error {
 					return err
 				}
 			}
-			if _, err := buf.WriteString(key); err != nil {
+			if _, err := buf.WriteString(quoteIdentifier(key)); err != nil {
 				return err
 			}
 		}
@@ -353,7 +361,7 @@ type columnState struct {
 }
 
 func (c *columnState) toString(buf *strings.Builder) error {
-	if _, err := fmt.Fprintf(buf, "%s ", c.name); err != nil {
+	if _, err := fmt.Fprintf(buf, "%s ", quoteIdentifier(c.name)); err != nil {
 		return err
 	}
 	if _, err := buf.WriteString(c.tp); err != nil {


### PR DESCRIPTION
## The bug

[`instance.ts:441`](frontend/src/utils/v1/instance.ts#L441) `supportGetStringSchema` lists `REDSHIFT`, so the SQL editor offers "view schema text" on Redshift tables and views. [`schema/redshift`](backend/plugin/schema/redshift/get_database_definition.go) registered only `GetDatabaseDefinition`, so both requests reached the registry with nothing behind them and came back `engine REDSHIFT is not supported`.

Redshift was the **last engine in that list with the gap**. Full survey:

| Engine | `TABLE` | `VIEW` |
|---|---|---|
| MYSQL / OCEANBASE / POSTGRES / TIDB / CLICKHOUSE / MSSQL | yes | yes |
| ORACLE | yes | yes ([#21348](https://github.com/bytebase/bytebase/pull/21348)) |
| **REDSHIFT** | **no** | **no** |

## The fix

The rendering already existed inside `writeTables` and `writeViews` — both had the per-object body inline. It's now `writeTable` and `writeView` taking one state each, called from the loops after the section banner and from the two new entry points without it. A single object renders exactly as its section of a full dump.

## Two more dump bugs found in review

**Names were unqualified.** `GetSchemaString` passes the requested schema and the wrappers discarded it, so a table in `analytics` came back as `CREATE TABLE orders`. The whole-database output had it worse: two schemas each with an `orders` table produced two identical `CREATE TABLE orders` statements. `tableState`/`viewState` now carry their schema and render `schema.name`, as pg — this state layer's ancestor — always has.

**Comments were interpolated raw.** A table commented `owner's orders` produced `COMMENT ON TABLE orders IS 'owner's orders';`, which will not replay. Table, column and view comments now go through `escapeSingleQuote`, the same doubling pg uses.

Both were pre-existing in the dump and are fixed there rather than only in the wrappers — the point of registering these handlers is that someone can copy the DDL out of the SQL editor, and neither an unqualified name nor a broken literal survives that.

## A determinism bug found while extracting it

The trailing `COMMENT ON COLUMN` statements came from ranging over `tableState.columns`, which is a **map**. So a table with more than one commented column produced a **different dump on every sync**, while the `CREATE TABLE` body directly above it was sorted by column id. Both now go through one `sortedColumns` helper and agree.

## Only table and view

Redshift renders nothing else — no materialized views, functions, procedures or sequences appear in `GetDatabaseDefinition` — so the remaining object types have no implementation to expose. Registering them would emit nothing or panic, the same reasoning that kept Oracle's sequences unregistered when the sync carried none of their attributes.

## And one more, from qualifying the names

Qualifying `CREATE TABLE` without qualifying its `REFERENCES` target left the two inconsistent — `analytics.child` referencing a bare `parent` binds to whatever the search path resolves. `getForeignKeys` keeps the qualifier in `ReferencedSchema` and `convertToForeignKeyState` was dropping it; it now goes through the same `qualifyName` helper.

## Testing

- `TestGetObjectDefinition` — exact rendering for a table with table and column comments, a view with a comment, a table outside the default schema, and comments containing apostrophes
- `TestObjectDefinitionsRegisteredForRedshift` — goes through the `schema` registry, because **the registry lookup is where the bug was**; a direct-call test passes against the broken code
- `TestColumnCommentOrderIsStable` — 200 generations of an 8-column table, all identical
- `TestGetDatabaseDefinitionKeepsSections` — pins the whole-database output the extraction had to preserve, and asserts the single-table output is a substring of it
- `golangci-lint` 0 issues, `gofmt`, `go vet`, server binary builds

The package had no tests at all before this.

## Not a breaking change

These paths returned an error before; they now return content. The one behavior change to existing output is column comments becoming deterministic.

## On "all engines"

I checked whether the other engines have the same gap and they do not. pg is missing `GetProcedureDefinition`, mssql is missing schema and sequence, mysql/tidb are missing sequence — but **none of those engines renders those object types at all** in its whole-database output, so there is no registration to add, only a renderer to write. And the frontend requests only `TABLE` and `VIEW`, both of which every engine now serves.

## Found and not fixed

**Catalog quote decoding, in the driver.** `getColumnList` and `formatTableNameFromRegclass` in [`db/redshift/sync.go`](backend/plugin/db/redshift/sync.go) do `strings.Trim(name, '"')`, which strips the outer quotes off canonical catalog text but leaves the internal doubling — a column named `od"d` is stored as `od""d`. That is a corrupted identifier in the metadata itself, inherited by the diff and the migration generator, not just by DDL generation. The fix is a `ReplaceAll` in those two functions, after which `quoteIdentifier` here is correct as written; compensating in the writer would hide the real problem.

**Composite foreign keys.** `foreignKeyState.toString` loops over the columns and writes a complete `FOREIGN KEY (col) REFERENCES t(col)` clause for each one, so a composite foreign key is emitted as several single-column constraints rather than one. Predates this PR, changes constraint semantics rather than qualification, and needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


