### PR TITLE
perf(tests): turn on parallelism in backend/store

### DIFF
--- a/backend/store/access_grant_filter_test.go
+++ b/backend/store/access_grant_filter_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestGetActiveAccessGrantFilter(t *testing.T) {
+	t.Parallel()
 	expireTime := time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC)
 	q := getActiveAccessGrantFilter(&FindActiveAccessGrantMessage{
 		Target:     "instances/prod/databases/app",
@@ -27,6 +28,7 @@ func TestGetActiveAccessGrantFilter(t *testing.T) {
 }
 
 func TestGetListAccessGrantFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -207,6 +209,7 @@ func TestGetListAccessGrantFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetListAccessGrantFilter(tt.filter)
 
 			if tt.wantErr {

--- a/backend/store/account_filter_test.go
+++ b/backend/store/account_filter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetAccountListFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -122,6 +123,7 @@ func TestGetAccountListFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := GetAccountListFilter(tt.filter)
 
 			if tt.wantErr {

--- a/backend/store/advisory_lock_test.go
+++ b/backend/store/advisory_lock_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTryAdvisoryXactLockWithStringKeyScopesByKey(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, _, _ := testcontainer.NewMetadataDB(t)
 	tx1, err := db.BeginTx(ctx, nil)

--- a/backend/store/audit_log_filter_test.go
+++ b/backend/store/audit_log_filter_test.go
@@ -15,6 +15,7 @@ func mustParseTime(t *testing.T, s string) time.Time {
 }
 
 func TestGetSearchAuditLogsFilter_WithoutUserLookup(t *testing.T) {
+	t.Parallel()
 	// Note: This test skips user filter tests since they require database access
 	// User filter functionality is tested in integration tests
 
@@ -138,6 +139,7 @@ func TestGetSearchAuditLogsFilter_WithoutUserLookup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetSearchAuditLogsFilter(tt.filter)
 
 			if tt.wantErr {
@@ -168,6 +170,7 @@ func TestGetSearchAuditLogsFilter_WithoutUserLookup(t *testing.T) {
 }
 
 func TestGetSearchAuditLogsFilter_EdgeCases(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -205,6 +208,7 @@ func TestGetSearchAuditLogsFilter_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetSearchAuditLogsFilter(tt.filter)
 
 			if tt.wantErr {

--- a/backend/store/audit_log_mcp_filter_test.go
+++ b/backend/store/audit_log_mcp_filter_test.go
@@ -26,6 +26,7 @@ import (
 // Postgres with one question mark instead of two is a parameter count error
 // rather than a query.
 func TestSearchAuditLogsMCPFilters(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, s, _ := testcontainer.NewMetadataDB(t)
 
@@ -85,6 +86,7 @@ func TestSearchAuditLogsMCPFilters(t *testing.T) {
 	}
 
 	t.Run("mcp == true returns every MCP row and only those", func(t *testing.T) {
+		t.Parallel()
 		got := search(t, "mcp == true")
 		require.Len(t, got, 4, "the four rows carrying the marker, including the empty-field legacy one")
 		for _, log := range got {
@@ -94,12 +96,14 @@ func TestSearchAuditLogsMCPFilters(t *testing.T) {
 	})
 
 	t.Run("mcp == false returns the rest", func(t *testing.T) {
+		t.Parallel()
 		got := search(t, "mcp == false")
 		require.Len(t, got, 1)
 		require.Nil(t, got[0].Payload.GetMcpDelegation())
 	})
 
 	t.Run("the correlation filter returns one session's rows", func(t *testing.T) {
+		t.Parallel()
 		got := search(t, `mcp_correlation_id == "session-one"`)
 		require.Len(t, got, 2)
 		for _, log := range got {
@@ -108,16 +112,19 @@ func TestSearchAuditLogsMCPFilters(t *testing.T) {
 	})
 
 	t.Run("the MCP filters compose with the existing ones", func(t *testing.T) {
+		t.Parallel()
 		got := search(t, `mcp == true && method == "/bytebase.v1.SQLService/Query"`)
 		require.Len(t, got, 3)
 	})
 
 	t.Run("an unknown key still errors", func(t *testing.T) {
+		t.Parallel()
 		_, err := store.GetSearchAuditLogsFilter(`mcp_client_id == "client-A"`)
 		require.ErrorContains(t, err, "unknown variable mcp_client_id")
 	})
 
 	t.Run("mcp is a boolean, not a string", func(t *testing.T) {
+		t.Parallel()
 		// Every other boolean filter key in the codebase takes a real CEL
 		// boolean and says so on a mismatch; this one must not be the outlier.
 		_, err := store.GetSearchAuditLogsFilter(`mcp == "true"`)

--- a/backend/store/audit_log_retention_test.go
+++ b/backend/store/audit_log_retention_test.go
@@ -41,6 +41,8 @@ const (
 // subscription path, so the feature gate, retention cutoff, filter application
 // and SQL execution are all exercised.
 func TestAuditLogRetentionFilteringEndToEnd(t *testing.T) {
+	// Not parallel: the subtests set the workspace license in turn and read it back,
+	// so they share one mutable row and have to run in order.
 	ctx, stores, licenseService := setupAuditLogRetentionTest(t)
 
 	now := time.Now().UTC()
@@ -97,6 +99,7 @@ func TestAuditLogRetentionFilteringEndToEnd(t *testing.T) {
 // ApplyRetentionFilter against real rows: a row created exactly at the cutoff
 // is retained and a row one microsecond earlier is dropped.
 func TestAuditLogRetentionFilterIncludesExactCutoffRow(t *testing.T) {
+	t.Parallel()
 	ctx, stores, _ := setupAuditLogRetentionTest(t)
 
 	cutoff := time.Now().UTC().Truncate(time.Microsecond)

--- a/backend/store/audit_log_test.go
+++ b/backend/store/audit_log_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestApplyRetentionFilter(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	sevenDaysAgo := now.AddDate(0, 0, -7)
 
@@ -67,6 +68,7 @@ func TestApplyRetentionFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := ApplyRetentionFilter(tt.userFilterQ, tt.cutoff)
 
 			require.NotNil(t, got, tt.description)

--- a/backend/store/batch_update_database_test.go
+++ b/backend/store/batch_update_database_test.go
@@ -21,6 +21,7 @@ func batchMoveDatabaseIntoProjectA(fixture *storePostgresFixture) error {
 }
 
 func TestBatchUpdateDatabasesRejectsArchivedInstance(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO instance (resource_id, workspace, project, deleted)
 			VALUES ('instance-a', 'default', NULL, TRUE);
@@ -38,6 +39,7 @@ func TestBatchUpdateDatabasesRejectsArchivedInstance(t *testing.T) {
 }
 
 func TestBatchUpdateDatabasesClearsEnvironmentOnArchivedInstance(t *testing.T) {
+	t.Parallel()
 	environmentID, unset := "env-a", ""
 	fixture := newStorePostgresFixture(t, `
 		INSERT INTO instance (resource_id, workspace, project, deleted)
@@ -60,6 +62,7 @@ func TestBatchUpdateDatabasesClearsEnvironmentOnArchivedInstance(t *testing.T) {
 }
 
 func TestBatchUpdateDatabasesByEnvironment(t *testing.T) {
+	t.Parallel()
 	envA, unset := "env-a", ""
 	fixture := newStorePostgresFixture(t, `
 		INSERT INTO workspace (resource_id) VALUES ('other');

--- a/backend/store/changelog_test.go
+++ b/backend/store/changelog_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestBuildListChangelogsQuerySchemaSnapshotBefore(t *testing.T) {
+	t.Parallel()
 	before, err := time.Parse(time.RFC3339Nano, "2024-12-31T23:59:59.123456789Z")
 	require.NoError(t, err)
 	database := "db"

--- a/backend/store/common_test.go
+++ b/backend/store/common_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestParseOrderBy(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		input string
 		want  []*OrderByKey

--- a/backend/store/database_filter_test.go
+++ b/backend/store/database_filter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetListDatabaseFilterInstanceScope(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		filter   string
@@ -29,6 +30,7 @@ func TestGetListDatabaseFilterInstanceScope(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			query, err := GetListDatabaseFilter("default", tt.filter)
 			require.NoError(t, err)
 

--- a/backend/store/database_group_test.go
+++ b/backend/store/database_group_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestBuildListDatabaseGroupsQueryMultiProjectFilter(t *testing.T) {
+	t.Parallel()
 	resourceID := "group-a"
 	tests := []struct {
 		name        string
@@ -59,6 +60,7 @@ func TestBuildListDatabaseGroupsQueryMultiProjectFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			query, args, err := buildListDatabaseGroupsQuery(tt.find)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)

--- a/backend/store/database_ownership_test.go
+++ b/backend/store/database_ownership_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestDatabaseWritersRespectProjectInstanceOwnership(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, `
 		ALTER TABLE instance ADD COLUMN IF NOT EXISTS project TEXT REFERENCES project(resource_id);
 		INSERT INTO project (resource_id, workspace, name) VALUES
@@ -117,6 +118,7 @@ func TestDatabaseWritersRespectProjectInstanceOwnership(t *testing.T) {
 }
 
 func TestListDatabasesIncludesInstanceProject(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, `
 		ALTER TABLE instance ADD COLUMN IF NOT EXISTS project TEXT REFERENCES project(resource_id);
 		INSERT INTO project (resource_id, workspace, name) VALUES ('project-b', 'default', 'Project B');
@@ -155,6 +157,7 @@ func getDatabaseProject(ctx context.Context, t *testing.T, s *store.Store, insta
 }
 
 func TestProjectInstanceDatabaseUpsertAllowsArchivedOwner(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, `
 		ALTER TABLE instance ADD COLUMN IF NOT EXISTS project TEXT REFERENCES project(resource_id);
 		INSERT INTO project (resource_id, workspace, name, deleted)
@@ -174,6 +177,7 @@ func TestProjectInstanceDatabaseUpsertAllowsArchivedOwner(t *testing.T) {
 }
 
 func TestProjectInstanceDatabaseUpdateAllowsArchivedOwner(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, `
 		ALTER TABLE instance ADD COLUMN IF NOT EXISTS project TEXT REFERENCES project(resource_id);
 		INSERT INTO project (resource_id, workspace, name, deleted)

--- a/backend/store/db_connection_lifecycle_test.go
+++ b/backend/store/db_connection_lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestMetadataDBConnectionCloseRunsCleanup(t *testing.T) {
+	t.Parallel()
 	cleanupCalls := 0
 	conn := &metadataDBConnection{
 		cleanup: func() error {
@@ -23,6 +24,7 @@ func TestMetadataDBConnectionCloseRunsCleanup(t *testing.T) {
 }
 
 func TestMetadataDBConnectionCloseReturnsCleanupError(t *testing.T) {
+	t.Parallel()
 	conn := &metadataDBConnection{
 		cleanup: func() error {
 			return errors.New("cleanup failed")

--- a/backend/store/db_connection_test.go
+++ b/backend/store/db_connection_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestIsFilePath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		in   string
@@ -66,6 +67,7 @@ func TestIsFilePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.want, isFilePath(tt.in))
 		})
 	}

--- a/backend/store/db_tracer_test.go
+++ b/backend/store/db_tracer_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestExtractQueryOperation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		sql      string
@@ -32,6 +33,7 @@ func TestExtractQueryOperation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := extractQueryOperation(tt.sql)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -39,6 +41,7 @@ func TestExtractQueryOperation(t *testing.T) {
 }
 
 func TestMetadataDBTracer_TraceQueryEnd(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		err            error
@@ -53,6 +56,7 @@ func TestMetadataDBTracer_TraceQueryEnd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tracer := &metadataDBTracer{}
 
 			// Start trace
@@ -80,6 +84,7 @@ func TestMetadataDBTracer_TraceQueryEnd(t *testing.T) {
 }
 
 func TestMetadataDBTracer_TraceQueryEnd_MissingContext(t *testing.T) {
+	t.Parallel()
 	tracer := &metadataDBTracer{}
 
 	// End trace without start - should not panic

--- a/backend/store/filter_test.go
+++ b/backend/store/filter_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestEscapeLikePattern(t *testing.T) {
+	t.Parallel()
 	// `%` and `_` are wildcards to LIKE. Left raw, a search for a statement
 	// holding either matched rows the user never asked for.
 	require.Equal(t, `100\% off`, escapeLikePattern("100% off"))
@@ -19,6 +20,7 @@ func TestEscapeLikePattern(t *testing.T) {
 }
 
 func TestContainsEscapesLikeWildcards(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		filter  string
@@ -59,6 +61,7 @@ func TestContainsEscapesLikeWildcards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			query, err := tt.build(tt.filter)
 			require.NoError(t, err)
 			sql, args, err := query.ToSQL()
@@ -70,6 +73,7 @@ func TestContainsEscapesLikeWildcards(t *testing.T) {
 }
 
 func TestLabelFilterAcceptsIndexSyntax(t *testing.T) {
+	t.Parallel()
 	// Label keys allow dashes (`^[a-z][a-z0-9_-]{0,62}$`). CEL parses
 	// `labels.cost-center` as subtraction, so the dotted form never reaches the
 	// store — index syntax is the only one that carries such a key. The key is
@@ -120,6 +124,7 @@ func TestLabelFilterAcceptsIndexSyntax(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			query, err := tt.build(tt.filter)
 			require.NoError(t, err)
 			sql, args, err := query.ToSQL()

--- a/backend/store/group_filter_test.go
+++ b/backend/store/group_filter_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestGetListGroupFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -101,6 +102,7 @@ func TestGetListGroupFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			find := &FindGroupMessage{}
 			q, err := GetListGroupFilter(find, tt.filter)
 
@@ -130,6 +132,7 @@ func TestGetListGroupFilter(t *testing.T) {
 }
 
 func TestGetListGroupFilterProject(t *testing.T) {
+	t.Parallel()
 	// Test project filter separately since it modifies the find struct
 	find := &FindGroupMessage{}
 	q, err := GetListGroupFilter(find, `project == "projects/test-project"`)
@@ -146,6 +149,7 @@ func TestGetListGroupFilterProject(t *testing.T) {
 }
 
 func TestProjectMembersGroupJoinCondition(t *testing.T) {
+	t.Parallel()
 	sql, args, err := projectMembersGroupJoinCondition().ToSQL()
 	require.NoError(t, err)
 	require.Contains(t, sql, "user_group.email")

--- a/backend/store/iam_policy_test.go
+++ b/backend/store/iam_policy_test.go
@@ -44,6 +44,7 @@ func projectPolicyMembers(ctx context.Context, t *testing.T, s *store.Store, wor
 // transaction, so both writers passed the compare and the later one clobbered
 // the other. If the lost edit was a revoke, access stayed granted.
 func TestSetIamPolicyCompareAndSwap(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO policy (workspace, resource_type, resource, type, payload, inherit_from_parent)
 			VALUES ('default', 'PROJECT', 'projects/project-a', 'IAM', '` + ownerAndDeveloperPolicy + `', FALSE);
@@ -119,6 +120,7 @@ func TestSetIamPolicyCompareAndSwap(t *testing.T) {
 // disagree with the row -- and comparing against it would accept exactly the
 // stale write the etag exists to reject.
 func TestSetIamPolicyComparesAgainstTheRowNotTheCache(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO policy (workspace, resource_type, resource, type, payload, inherit_from_parent)
 			VALUES ('default', 'PROJECT', 'projects/project-a', 'IAM', '` + ownerAndDeveloperPolicy + `', FALSE);
@@ -183,6 +185,7 @@ func TestSetIamPolicyComparesAgainstTheRowNotTheCache(t *testing.T) {
 // caller leaves a gap another request can land in, so two writes both pass a
 // guard neither would have passed against what the other stored.
 func TestSetIamPolicyValidatesAgainstTheReplacedPolicy(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO policy (workspace, resource_type, resource, type, payload, inherit_from_parent)
 			VALUES ('default', 'PROJECT', 'projects/project-a', 'IAM', '` + ownerAndDeveloperPolicy + `', FALSE);
@@ -216,6 +219,7 @@ func TestSetIamPolicyValidatesAgainstTheReplacedPolicy(t *testing.T) {
 // workspaces name their projects independently -- so the same resource string
 // exists in both. A write must touch only the workspace it named.
 func TestSetIamPolicyIsScopedToItsWorkspace(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO workspace (resource_id) VALUES ('other');
 		INSERT INTO policy (workspace, resource_type, resource, type, payload, inherit_from_parent)
@@ -242,6 +246,7 @@ func TestSetIamPolicyIsScopedToItsWorkspace(t *testing.T) {
 // A resource whose IAM policy was never written has no row to lock, so the
 // first write creates one rather than failing the compare.
 func TestSetIamPolicyCreatesTheFirstPolicy(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, "")
 	ctx, s := fixture.ctx, fixture.store
 
@@ -267,6 +272,7 @@ func TestSetIamPolicyCreatesTheFirstPolicy(t *testing.T) {
 // policy, and now does it inside the locked transaction. Its merge semantics
 // must be unchanged by that move.
 func TestPatchWorkspaceIamPolicyMerges(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, "")
 	ctx, s := fixture.ctx, fixture.store
 
@@ -316,6 +322,7 @@ func TestPatchWorkspaceIamPolicyMerges(t *testing.T) {
 // changed. Approving a role grant while an admin revokes someone in the same
 // project put the revoked member back.
 func TestPatchIamPolicyMergesIntoTheStoredPolicy(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO policy (workspace, resource_type, resource, type, payload, inherit_from_parent)
 			VALUES ('default', 'PROJECT', 'projects/project-a', 'IAM', '` + ownerAndDeveloperPolicy + `', FALSE);
@@ -361,6 +368,7 @@ func TestPatchIamPolicyMergesIntoTheStoredPolicy(t *testing.T) {
 // A mutation that fails leaves the policy alone rather than committing a
 // half-applied merge.
 func TestPatchIamPolicyRollsBackAFailedMutation(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO policy (workspace, resource_type, resource, type, payload, inherit_from_parent)
 			VALUES ('default', 'PROJECT', 'projects/project-a', 'IAM', '` + ownerAndDeveloperPolicy + `', FALSE);
@@ -387,6 +395,7 @@ func TestPatchIamPolicyRollsBackAFailedMutation(t *testing.T) {
 // goroutines: after a write, the row is changed out of band, and a read that
 // still saw the written value would prove the write had published it.
 func TestSetIamPolicyDoesNotPublishItsOwnWrite(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO policy (workspace, resource_type, resource, type, payload, inherit_from_parent)
 			VALUES ('default', 'PROJECT', 'projects/project-a', 'IAM', '` + ownerAndDeveloperPolicy + `', FALSE);

--- a/backend/store/instance_filter_test.go
+++ b/backend/store/instance_filter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetListInstanceFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -49,6 +50,7 @@ func TestGetListInstanceFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetListInstanceFilter(tt.filter)
 
 			if tt.wantErr {

--- a/backend/store/instance_project_test.go
+++ b/backend/store/instance_project_test.go
@@ -40,6 +40,7 @@ func testInstanceMetadata() *storepb.Instance {
 }
 
 func TestCreateAndListProjectInstance(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newInstanceProjectFixture(t)
 	projectID := "project-a"
 	instance, err := s.CreateInstance(ctx, &store.InstanceMessage{
@@ -124,6 +125,7 @@ func TestCreateAndListProjectInstance(t *testing.T) {
 }
 
 func TestUpdateInstanceWithoutWorkspace(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newInstanceProjectFixture(t)
 	instance, err := s.CreateInstance(ctx, &store.InstanceMessage{
 		ResourceID: "workspace-instance",
@@ -142,9 +144,11 @@ func TestUpdateInstanceWithoutWorkspace(t *testing.T) {
 }
 
 func TestCreateProjectInstanceRejectsDefaultDeletedAndMissingProject(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newInstanceProjectFixture(t)
 	for _, projectID := range []string{"default", "deleted-project", "missing-project"} {
 		t.Run(projectID, func(t *testing.T) {
+			t.Parallel()
 			_, err := s.CreateInstance(ctx, &store.InstanceMessage{
 				ResourceID: projectID + "-instance",
 				Workspace:  "default",
@@ -157,6 +161,7 @@ func TestCreateProjectInstanceRejectsDefaultDeletedAndMissingProject(t *testing.
 }
 
 func TestDeleteProjectDeletesProjectInstancesAndKeepsWorkspaceInstanceDatabases(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newInstanceProjectFixture(t)
 	_, err := db.ExecContext(ctx, `
 		UPDATE project SET deleted = TRUE WHERE resource_id = 'project-a';
@@ -189,6 +194,7 @@ func TestDeleteProjectDeletesProjectInstancesAndKeepsWorkspaceInstanceDatabases(
 }
 
 func TestDeleteProjectInstancePurgesHistory(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newInstanceProjectFixture(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO instance (resource_id, workspace, project, deleted) VALUES

--- a/backend/store/instance_purge_cache_test.go
+++ b/backend/store/instance_purge_cache_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDeleteInstancePurgeInvalidatesDescendantCaches(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newProjectPurgeCacheFixture(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO instance (resource_id, workspace, project, deleted)

--- a/backend/store/issue_comment_thread_test.go
+++ b/backend/store/issue_comment_thread_test.go
@@ -19,6 +19,7 @@ import (
 // creation with its root invariants, resolve/reopen on the root only, the
 // timeline and reply list filters, and statement anchor round-trips.
 func TestIssueCommentThreads(t *testing.T) {
+	t.Parallel()
 	const (
 		workspaceID  = "thread-ws"
 		projectID    = "thread-p"

--- a/backend/store/issue_list_filter_integration_test.go
+++ b/backend/store/issue_list_filter_integration_test.go
@@ -23,6 +23,7 @@ import (
 //   - create_time is documented as ">=" and "<=" but was implemented as ">" and
 //     "<", excluding an issue at the exact boundary.
 func TestIssueListFilterEdgeCases(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, stores, _ := testcontainer.NewMetadataDB(t)
 	_, err := db.ExecContext(ctx, `
@@ -91,6 +92,7 @@ func TestIssueListFilterEdgeCases(t *testing.T) {
 // issue. A flat role list without the project pairing passes every other
 // assertion in this file and fails this one.
 func TestIssueListNextApproverIsProjectScoped(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, stores, _ := testcontainer.NewMetadataDB(t)
 	_, err := db.ExecContext(ctx, `

--- a/backend/store/issue_search_test.go
+++ b/backend/store/issue_search_test.go
@@ -10,6 +10,7 @@ import (
 // raw builds an invalid tsquery — `(`, `:`, `'`, `&`, `|` and `!` are tsquery
 // syntax — which fails the whole issue list at cast time.
 func TestGetTSQueryRejectsNonLexemeText(t *testing.T) {
+	t.Parallel()
 	for _, text := range []string{"(", ")", ":", "'", "&", "|", "!", "!!!", "<->", " ", `\`} {
 		require.Empty(t, getTSQuery(text), "getTSQuery(%q)", text)
 	}

--- a/backend/store/issue_service_concurrency_test.go
+++ b/backend/store/issue_service_concurrency_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestDraftLabelUpdateConflictsWithConcurrentSubmission(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	service, issueBus := newIssueServiceForTest(t, stores)
@@ -80,6 +81,7 @@ func TestDraftLabelUpdateConflictsWithConcurrentSubmission(t *testing.T) {
 }
 
 func TestConcurrentSubmissionWithLabelsWritesOneAuditComment(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	service, issueBus := newIssueServiceForTest(t, stores)
@@ -131,6 +133,7 @@ func TestConcurrentSubmissionWithLabelsWritesOneAuditComment(t *testing.T) {
 }
 
 func TestConcurrentIdenticalLabelUpdatesCreateOneAuditComment(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	service, _ := newIssueServiceForTest(t, stores)
@@ -171,6 +174,7 @@ func TestConcurrentIdenticalLabelUpdatesCreateOneAuditComment(t *testing.T) {
 }
 
 func TestConcurrentIdenticalTitleUpdatesCreateOneAuditComment(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	service, _ := newIssueServiceForTest(t, stores)
@@ -210,6 +214,7 @@ func TestConcurrentIdenticalTitleUpdatesCreateOneAuditComment(t *testing.T) {
 }
 
 func TestMixedIssuePatchRollsBackWhenLabelsFail(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	service, _ := newIssueServiceForTest(t, stores)
@@ -243,12 +248,14 @@ func TestMixedIssuePatchRollsBackWhenLabelsFail(t *testing.T) {
 }
 
 func TestCreateDraftAndRolloutAreSerialized(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	service, _ := newIssueServiceForTest(t, stores)
 
 	for i := range 10 {
 		t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
+			t.Parallel()
 			plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
 				ProjectID: "project-a",
 				Name:      "draft rollout race",
@@ -318,6 +325,7 @@ func TestCreateDraftAndRolloutAreSerialized(t *testing.T) {
 }
 
 func TestCreateDraftIssueIsIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	b, err := bus.New()
@@ -443,6 +451,7 @@ func TestCreateDraftIssueIsIdempotent(t *testing.T) {
 }
 
 func TestIssueApprovalFiltersRunBeforePaging(t *testing.T) {
+	t.Parallel()
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
 	service, _ := newIssueServiceForTest(t, stores)

--- a/backend/store/issue_test.go
+++ b/backend/store/issue_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCanonicalizeIssueLabels(t *testing.T) {
+	t.Parallel()
 	got := CanonicalizeIssueLabels([]string{
 		" release ",
 		"bug",
@@ -21,6 +22,7 @@ func TestCanonicalizeIssueLabels(t *testing.T) {
 }
 
 func TestCanonicalizeIssueLabelsEmpty(t *testing.T) {
+	t.Parallel()
 	require.Empty(t, CanonicalizeIssueLabels(nil))
 	require.Empty(t, CanonicalizeIssueLabels([]string{"", " ", "\t"}))
 }

--- a/backend/store/login_attempt_test.go
+++ b/backend/store/login_attempt_test.go
@@ -22,6 +22,8 @@ import (
 // nothing (so the lock expires exactly D after the Nth attempt), the counter
 // forgets after D of quiet, and success deletes the row.
 func TestLoginAttemptClaim(t *testing.T) {
+	// Not parallel: the purge subtest asserts a table-wide delete count, which only
+	// holds while no other subtest is writing login_attempt rows.
 	ctx := context.Background()
 	db, s, _ := testcontainer.NewMetadataDB(t)
 
@@ -194,6 +196,7 @@ func TestLoginAttemptClaim(t *testing.T) {
 // TestSendBudgetClaim covers the outbound send budget: the same ClaimAttempt as
 // the lockout, under the window rule EMAIL_CODE_SEND selects.
 func TestSendBudgetClaim(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, s, _ := testcontainer.NewMetadataDB(t)
 
@@ -210,6 +213,7 @@ func TestSendBudgetClaim(t *testing.T) {
 	}
 
 	t.Run("grants exactly max per window", func(t *testing.T) {
+		t.Parallel()
 		const key = "sender-a"
 		for i := range 3 {
 			granted, err := s.ClaimAttempt(ctx, key, kind, 3, window)
@@ -226,6 +230,7 @@ func TestSendBudgetClaim(t *testing.T) {
 	// never resets it and "3 per hour" would become "3 ever, until an hour of
 	// silence", refusing traffic that never approached the rate.
 	t.Run("a steady trickle does not accumulate across windows", func(t *testing.T) {
+		t.Parallel()
 		const key = "sender-trickle"
 		// Six sends, each arriving well inside the window but with the window
 		// itself rolling over between every pair. A lockout counter would reach
@@ -241,6 +246,7 @@ func TestSendBudgetClaim(t *testing.T) {
 	})
 
 	t.Run("a full window reopens once it expires", func(t *testing.T) {
+		t.Parallel()
 		const key = "sender-expiry"
 		for range 2 {
 			granted, err := s.ClaimAttempt(ctx, key, kind, 2, window)
@@ -258,6 +264,7 @@ func TestSendBudgetClaim(t *testing.T) {
 	})
 
 	t.Run("refusals do not extend the window", func(t *testing.T) {
+		t.Parallel()
 		const key = "sender-refusal"
 		granted, err := s.ClaimAttempt(ctx, key, kind, 1, window)
 		require.NoError(t, err)
@@ -280,6 +287,7 @@ func TestSendBudgetClaim(t *testing.T) {
 	})
 
 	t.Run("senders and kinds are independent", func(t *testing.T) {
+		t.Parallel()
 		granted, err := s.ClaimAttempt(ctx, "sender-x", kind, 1, window)
 		require.NoError(t, err)
 		require.True(t, granted)
@@ -292,6 +300,7 @@ func TestSendBudgetClaim(t *testing.T) {
 	})
 
 	t.Run("an unkeyed claim is refused outright", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.ClaimAttempt(ctx, "", kind, 1, window)
 		require.Error(t, err)
 	})

--- a/backend/store/mfa_pending_version_test.go
+++ b/backend/store/mfa_pending_version_test.go
@@ -24,6 +24,7 @@ import (
 // it struck roughly half of all enrollments — so the instants here are chosen
 // rather than sampled from time.Now().
 func TestPendingMFAVersionSurvivesNanosecondClocks(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newSettingAtomicFixture(t)
 	a := require.New(t)
 

--- a/backend/store/oauth2_consume_test.go
+++ b/backend/store/oauth2_consume_test.go
@@ -22,6 +22,7 @@ import (
 // succeed (the double-mint race that the prior read-then-delete flow allowed),
 // and a second sequential redemption must observe consumed=false.
 func TestOAuth2AtomicConsume(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, s, _ := testcontainer.NewMetadataDB(t)
 
@@ -34,6 +35,7 @@ func TestOAuth2AtomicConsume(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("authorization code is single-use", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2AuthorizationCode(ctx, &store.OAuth2AuthorizationCodeMessage{
 			Code:      "code-single-use",
 			ClientID:  "client-A",
@@ -54,12 +56,14 @@ func TestOAuth2AtomicConsume(t *testing.T) {
 	})
 
 	t.Run("consuming an unknown code returns false without error", func(t *testing.T) {
+		t.Parallel()
 		consumed, err := s.ConsumeOAuth2AuthorizationCode(ctx, "client-A", "never-existed")
 		require.NoError(t, err)
 		require.False(t, consumed)
 	})
 
 	t.Run("concurrent redemption of one code claims it exactly once", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2AuthorizationCode(ctx, &store.OAuth2AuthorizationCodeMessage{
 			Code:      "code-racy",
 			ClientID:  "client-A",
@@ -95,6 +99,7 @@ func TestOAuth2AtomicConsume(t *testing.T) {
 	})
 
 	t.Run("refresh token is single-use", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2RefreshToken(ctx, &store.OAuth2RefreshTokenMessage{
 			TokenHash: "rt-single-use",
 			ClientID:  "client-A",
@@ -114,6 +119,7 @@ func TestOAuth2AtomicConsume(t *testing.T) {
 	})
 
 	t.Run("concurrent refresh of one token claims it exactly once", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2RefreshToken(ctx, &store.OAuth2RefreshTokenMessage{
 			TokenHash: "rt-racy",
 			ClientID:  "client-A",

--- a/backend/store/oauth2_workspace_test.go
+++ b/backend/store/oauth2_workspace_test.go
@@ -30,6 +30,7 @@ import (
 //     back as "" so the handler's fallback chain to client.Workspace /
 //     singleton can take over.
 func TestOAuth2WorkspaceBinding(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, s, _ := testcontainer.NewMetadataDB(t)
 
@@ -44,6 +45,7 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("auth code round-trips workspace bound at consent time", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2AuthorizationCode(ctx, &store.OAuth2AuthorizationCodeMessage{
 			Code:      "code-with-ws",
 			ClientID:  "client-A",
@@ -62,6 +64,7 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 	})
 
 	t.Run("auth code with empty workspace stays empty for legacy fallback", func(t *testing.T) {
+		t.Parallel()
 		// Simulates a pre-3.18.2 auth code created before the workspace
 		// column existed. The migration added the column as nullable, so
 		// existing rows have NULL and Get returns "".
@@ -83,6 +86,7 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 	})
 
 	t.Run("refresh token preserves workspace across refresh", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2RefreshToken(ctx, &store.OAuth2RefreshTokenMessage{
 			TokenHash: "rt-hash-1",
 			ClientID:  "client-A",
@@ -100,6 +104,7 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 	})
 
 	t.Run("refresh token with empty workspace stays empty", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2RefreshToken(ctx, &store.OAuth2RefreshTokenMessage{
 			TokenHash: "rt-hash-2",
 			ClientID:  "client-A",
@@ -119,6 +124,7 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 	// boundary: a refresh reads it back to re-issue the same grant, so a dropped
 	// value would silently widen or unbind the session.
 	t.Run("refresh token config round-trips resource and scope", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2RefreshToken(ctx, &store.OAuth2RefreshTokenMessage{
 			TokenHash: "rt-hash-3",
 			ClientID:  "client-A",
@@ -140,6 +146,7 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 	})
 
 	t.Run("refresh token with no config stays empty", func(t *testing.T) {
+		t.Parallel()
 		// Both parameters are optional, and rows written before 3.22.1 default to
 		// '{}' — either way the handler must see "" and carry "" forward.
 		_, err := s.CreateOAuth2RefreshToken(ctx, &store.OAuth2RefreshTokenMessage{
@@ -159,6 +166,7 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 	})
 
 	t.Run("auth code config round-trips resource and scope", func(t *testing.T) {
+		t.Parallel()
 		_, err := s.CreateOAuth2AuthorizationCode(ctx, &store.OAuth2AuthorizationCodeMessage{
 			Code:      "code-with-resource",
 			ClientID:  "client-A",

--- a/backend/store/pagination_integration_test.go
+++ b/backend/store/pagination_integration_test.go
@@ -25,6 +25,7 @@ import (
 // issue IDs restart per project, so every id below is tied three ways and rows
 // cross the page boundary between reads.
 func TestPaginationStabilityAcrossProjects(t *testing.T) {
+	t.Parallel()
 	const (
 		workspaceID  = "pagination-ws"
 		projectCount = 3
@@ -110,6 +111,7 @@ func seedTiedIssues(ctx context.Context, t *testing.T, db *sql.DB, workspaceID s
 // The feed would then be stably scrambled: "labels changed" above "title
 // changed", permanently, for that issue.
 func TestIssueCommentBatchKeepsInsertionOrder(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, stores, _ := testcontainer.NewMetadataDB(t)
 

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestClaimAvailablePlanCheckRunsDefaultsMissingApprovalInputVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -41,6 +42,7 @@ func TestClaimAvailablePlanCheckRunsDefaultsMissingApprovalInputVersion(t *testi
 }
 
 func TestClaimAvailablePlanCheckRunsSkipsArchivedProjects(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -80,6 +82,7 @@ func TestClaimAvailablePlanCheckRunsSkipsArchivedProjects(t *testing.T) {
 }
 
 func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -135,6 +138,7 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(
 }
 
 func TestUpdatePlanCheckRunIfApprovalInputVersionAllowsClaimedRowAfterPlanVersionBump(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -180,6 +184,7 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionAllowsClaimedRowAfterPlanVersio
 }
 
 func TestCreatePlanCheckRunDoesNotResetActiveSameVersionRun(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -220,6 +225,7 @@ func TestCreatePlanCheckRunDoesNotResetActiveSameVersionRun(t *testing.T) {
 }
 
 func TestCreatePlanCheckRunDoesNotResetActiveSameVersionAvailableRun(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -255,6 +261,7 @@ func TestCreatePlanCheckRunDoesNotResetActiveSameVersionAvailableRun(t *testing.
 }
 
 func TestCreatePlanCheckRunAllowsTerminalSameVersionRerun(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -304,6 +311,7 @@ func TestCreatePlanCheckRunAllowsTerminalSameVersionRerun(t *testing.T) {
 }
 
 func TestCreatePlanCheckRunSkipsStaleIncomingApprovalInputVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -339,6 +347,7 @@ func TestCreatePlanCheckRunSkipsStaleIncomingApprovalInputVersion(t *testing.T) 
 }
 
 func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -375,6 +384,7 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(
 }
 
 func TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleCheck(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -423,6 +433,7 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleChe
 }
 
 func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsSameVersionRow(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -470,6 +481,7 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsSameVersionRow(t *te
 }
 
 func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotRewindNewerRow(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -516,6 +528,7 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotRewindNewerRow(t *
 }
 
 func TestCancelPlanCheckRunIfApprovalInputVersionSkipsRefreshedRow(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -570,6 +583,7 @@ func TestCancelPlanCheckRunIfApprovalInputVersionSkipsRefreshedRow(t *testing.T)
 }
 
 func TestCancelPlanCheckRunIfApprovalInputVersionAllowsObservedStaleRow(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -607,6 +621,7 @@ func TestCancelPlanCheckRunIfApprovalInputVersionAllowsObservedStaleRow(t *testi
 }
 
 func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 

--- a/backend/store/plan_filter_test.go
+++ b/backend/store/plan_filter_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestGetListPlanFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -178,6 +179,7 @@ func TestGetListPlanFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if tt.skipTest {
 				t.Skip("Test requires database connection")
 			}

--- a/backend/store/policy_project_iam_test.go
+++ b/backend/store/policy_project_iam_test.go
@@ -23,6 +23,7 @@ import (
 // the read into another workspace, another resource type, or — worst — another
 // policy type, whose payload would then be unmarshalled as an IamPolicy.
 func TestListProjectIamPoliciesIsScoped(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, stores, _ := testcontainer.NewMetadataDB(t)
 	_, err := db.ExecContext(ctx, `

--- a/backend/store/predefined_roles_test.go
+++ b/backend/store/predefined_roles_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestProjectOwnerInstancePermissions(t *testing.T) {
+	t.Parallel()
 	role := GetPredefinedRole(ProjectOwnerRole)
 	require.NotNil(t, role)
 
@@ -28,6 +29,7 @@ func TestProjectOwnerInstancePermissions(t *testing.T) {
 
 // Test that every permission in predefined roles is also defined in permission.yaml.
 func TestPredefinedRolesPermissionsExist(t *testing.T) {
+	t.Parallel()
 	a := require.New(t)
 
 	for _, role := range PredefinedRoles {

--- a/backend/store/project_filter_test.go
+++ b/backend/store/project_filter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetListProjectFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -141,6 +142,7 @@ func TestGetListProjectFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetListProjectFilter("test-workspace", tt.filter)
 
 			if tt.wantErr {

--- a/backend/store/project_purge_cache_test.go
+++ b/backend/store/project_purge_cache_test.go
@@ -95,6 +95,7 @@ func warmProjectPurgeCaches(ctx context.Context, t *testing.T, s *store.Store) {
 // immediately unavailable through the cached getters while surviving rows
 // still resolve correctly.
 func TestDeleteProjectPurgeInvalidatesDescendantCaches(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newProjectPurgeCacheFixture(t)
 	seedProjectPurgeFixture(ctx, t, db)
 	warmProjectPurgeCaches(ctx, t, s)
@@ -150,6 +151,7 @@ func TestDeleteProjectPurgeInvalidatesDescendantCaches(t *testing.T) {
 // data. Reused rows are inserted directly so a stale cache entry would still
 // be observable through the getters.
 func TestDeleteProjectPurgeSupportsDescendantIDReuse(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newProjectPurgeCacheFixture(t)
 	seedProjectPurgeFixture(ctx, t, db)
 	warmProjectPurgeCaches(ctx, t, s)
@@ -192,6 +194,7 @@ func TestDeleteProjectPurgeSupportsDescendantIDReuse(t *testing.T) {
 // directly, so any surviving getter result can only come from the still-warm
 // cache entries.
 func TestDeleteProjectFailedTransactionKeepsDescendantCaches(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newProjectPurgeCacheFixture(t)
 	seedProjectPurgeFixture(ctx, t, db)
 	warmProjectPurgeCaches(ctx, t, s)

--- a/backend/store/project_setting_cache_test.go
+++ b/backend/store/project_setting_cache_test.go
@@ -16,6 +16,7 @@ import (
 // pre-update row and caches it, so the stale setting outlives the write and
 // every later authorization check runs on it.
 func TestUpdateProjectsDoesNotLeaveAStaleSettingCached(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, `
 		UPDATE project SET setting = '{"allowLastPlanEditorApproval": true}' WHERE resource_id = 'project-a';
 	`)

--- a/backend/store/query_history_filter_test.go
+++ b/backend/store/query_history_filter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetListQueryHistoryFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -178,6 +179,7 @@ func TestGetListQueryHistoryFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetListQueryHistoryFilter(tt.filter)
 
 			if tt.wantErr {
@@ -206,6 +208,7 @@ func TestGetListQueryHistoryFilter(t *testing.T) {
 }
 
 func TestGetListQueryHistoryFilter_EdgeCases(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -267,6 +270,7 @@ func TestGetListQueryHistoryFilter_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetListQueryHistoryFilter(tt.filter)
 
 			if tt.wantErr {
@@ -291,6 +295,7 @@ func TestGetListQueryHistoryFilter_EdgeCases(t *testing.T) {
 // TestGetListQueryHistoryFilter_CompareWithOriginal verifies that the new implementation
 // produces equivalent SQL to the original v1 implementation
 func TestGetListQueryHistoryFilter_CompareWithOriginal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		filter             string
@@ -325,6 +330,7 @@ func TestGetListQueryHistoryFilter_CompareWithOriginal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetListQueryHistoryFilter(tt.filter)
 			require.NoError(t, err)
 			require.NotNil(t, q)
@@ -341,6 +347,7 @@ func TestGetListQueryHistoryFilter_CompareWithOriginal(t *testing.T) {
 }
 
 func TestGetListQueryHistoriesCreatorFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		filter      string
@@ -391,6 +398,7 @@ func TestGetListQueryHistoriesCreatorFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			creator, err := GetListQueryHistoriesCreatorFilter(tt.filter)
 			if tt.errContains != "" {
 				require.Error(t, err)

--- a/backend/store/review_run_test.go
+++ b/backend/store/review_run_test.go
@@ -14,6 +14,7 @@ import (
 // TestReviewRunStoreLifecycle walks the slot through reset, claim, supersede,
 // fenced completion, and heartbeat reaping against a real PostgreSQL.
 func TestReviewRunStoreLifecycle(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, `
 		INSERT INTO issue (id, creator, project, name, status, type)
 		VALUES (201, 'admin@example.com', 'default', 'Issue Default', 'OPEN', 'DATABASE_CHANGE');

--- a/backend/store/rollout_filter_test.go
+++ b/backend/store/rollout_filter_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestGetListRolloutFilter(t *testing.T) {
+	t.Parallel()
 	// The subquery used for update_time filtering
 	updatedAtSubquery := `COALESCE((SELECT MAX(task_run.updated_at) FROM task JOIN task_run ON task_run.project = task.project AND task_run.task_id = task.id WHERE task.project = plan.project AND task.plan_id = plan.id), plan.created_at)`
 
@@ -125,6 +126,7 @@ func TestGetListRolloutFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			q, err := GetListRolloutFilter(tt.filter)
 
 			if tt.wantErr {

--- a/backend/store/sample_instance_test.go
+++ b/backend/store/sample_instance_test.go
@@ -32,6 +32,7 @@ func newSampleInstanceFixture(t *testing.T) (context.Context, *store.Store) {
 }
 
 func TestSampleInstanceSetupPersistsOpaquePayload(t *testing.T) {
+	t.Parallel()
 	ctx, stores := newSampleInstanceFixture(t)
 	create := &store.SampleInstanceSetupMessage{
 		WorkspaceID: "workspace-a",
@@ -63,6 +64,7 @@ func TestSampleInstanceSetupPersistsOpaquePayload(t *testing.T) {
 }
 
 func TestSampleInstanceSetupPermanentLifecycle(t *testing.T) {
+	t.Parallel()
 	ctx, stores := newSampleInstanceFixture(t)
 	setup := &store.SampleInstanceSetupMessage{
 		WorkspaceID: "workspace-a",
@@ -99,6 +101,7 @@ func TestSampleInstanceSetupPermanentLifecycle(t *testing.T) {
 }
 
 func TestSampleInstanceSetupCleanupIsWorkspaceScoped(t *testing.T) {
+	t.Parallel()
 	ctx, stores := newSampleInstanceFixture(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	for _, workspace := range []string{"workspace-a", "workspace-b"} {
@@ -143,6 +146,7 @@ func TestSampleInstanceSetupCleanupIsWorkspaceScoped(t *testing.T) {
 }
 
 func TestSampleInstanceSetupDeletedRowRemainsTombstone(t *testing.T) {
+	t.Parallel()
 	ctx, stores := newSampleInstanceFixture(t)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	expiresAt := now.Add(time.Hour)

--- a/backend/store/saved_query_bindings_test.go
+++ b/backend/store/saved_query_bindings_test.go
@@ -15,6 +15,7 @@ import (
 // Nothing else asserts the shape directly, so a change to it would surface as
 // sharing silently matching no rows.
 func TestSavedQueryBindingsStoredShape(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO saved_query (resource_id, creator, project, name, statement)
 			VALUES ('saved-query-a', 'owner@example.com', 'project-a', 'Saved Query A', 'SELECT 1;');
@@ -96,6 +97,7 @@ func TestSavedQueryBindingsStoredShape(t *testing.T) {
 // grants along or every saved query shared with it becomes unreachable to its
 // members.
 func TestSavedQueryBindingsFollowGroupRename(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO user_group (id, email, workspace, name, description, payload)
 			VALUES ('group-1', 'eng@example.com', 'default', 'Eng', '', '{}');

--- a/backend/store/saved_query_folder_test.go
+++ b/backend/store/saved_query_folder_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestNormalizeSavedQueryFolder(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name    string
 		folder  string
@@ -22,6 +23,7 @@ func TestNormalizeSavedQueryFolder(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := NormalizeSavedQueryFolder(tc.folder)
 			if tc.wantErr {
 				require.Error(t, err)

--- a/backend/store/saved_query_lock_order_test.go
+++ b/backend/store/saved_query_lock_order_test.go
@@ -19,6 +19,7 @@ func savedQueryStarCount(t *testing.T, fixture *storePostgresFixture) int {
 }
 
 func TestSavedQueryDeleteAndStarToggleLockOrder(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO saved_query (resource_id, creator, project, name, statement)
 			VALUES ('saved-query-a', 'user@example.com', 'default', 'Saved Query A', '');
@@ -26,6 +27,7 @@ func TestSavedQueryDeleteAndStarToggleLockOrder(t *testing.T) {
 	`
 
 	t.Run("delete first", func(t *testing.T) {
+		t.Parallel()
 		fixture := newStorePostgresFixture(t, seedSQL)
 		const barrierID = 9935
 		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
@@ -62,6 +64,7 @@ func TestSavedQueryDeleteAndStarToggleLockOrder(t *testing.T) {
 	})
 
 	t.Run("toggle first", func(t *testing.T) {
+		t.Parallel()
 		fixture := newStorePostgresFixture(t, seedSQL)
 		const barrierID = 9936
 		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
@@ -94,6 +97,7 @@ func TestSavedQueryDeleteAndStarToggleLockOrder(t *testing.T) {
 }
 
 func TestSavedQueryBatchFolderMovesLockOrder(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO saved_query (resource_id, creator, project, name, statement, folder) VALUES
 			('saved-query-a', 'user@example.com', 'default', 'A', '', 'start'),
@@ -141,6 +145,7 @@ func TestSavedQueryBatchFolderMovesLockOrder(t *testing.T) {
 }
 
 func TestCreateSavedQueryRejectsInactiveProject(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, "")
 
 	_, err := fixture.store.CreateSavedQuery(fixture.ctx, &store.SavedQueryMessage{
@@ -172,6 +177,7 @@ func TestCreateSavedQueryRejectsInactiveProject(t *testing.T) {
 }
 
 func TestSavedQueryFolderPrefixMovesLockOrder(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO saved_query (resource_id, creator, project, name, statement, folder) VALUES
 			('saved-query-a', 'user@example.com', 'default', 'A', '', 'a'),
@@ -195,6 +201,7 @@ func TestSavedQueryFolderPrefixMovesLockOrder(t *testing.T) {
 	}
 
 	t.Run("parent first", func(t *testing.T) {
+		t.Parallel()
 		fixture := newStorePostgresFixture(t, seedSQL)
 		const barrierID = 9961
 		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
@@ -226,6 +233,7 @@ func TestSavedQueryFolderPrefixMovesLockOrder(t *testing.T) {
 	})
 
 	t.Run("child first", func(t *testing.T) {
+		t.Parallel()
 		fixture := newStorePostgresFixture(t, seedSQL)
 		const barrierID = 9962
 		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
@@ -258,6 +266,7 @@ func TestSavedQueryFolderPrefixMovesLockOrder(t *testing.T) {
 }
 
 func TestSavedQueryWritersProjectScoped(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO saved_query (resource_id, creator, project, name, statement, folder)
 			VALUES ('saved-query-a', 'user@example.com', 'project-a', 'Saved Query A', '', 'kept');

--- a/backend/store/saved_query_purge_isolation_test.go
+++ b/backend/store/saved_query_purge_isolation_test.go
@@ -14,6 +14,7 @@ import (
 // rows belonging to a surviving project must not be collateral.
 
 func TestDeleteProjectPurgeKeepsOtherProjectSavedQueryStars(t *testing.T) {
+	t.Parallel()
 	const seedSQL = `
 		INSERT INTO project (resource_id, workspace, name) VALUES ('project-b', 'default', 'Project B');
 		INSERT INTO service_account (name, email, workspace, service_key_hash, project)

--- a/backend/store/setting_atomic_test.go
+++ b/backend/store/setting_atomic_test.go
@@ -59,6 +59,7 @@ func mustProfile(t *testing.T, setting *store.SettingMessage) *storepb.Workspace
 // Against a read-then-UpsertSetting implementation this fails: the second
 // update merges onto a stale read and silently reverts the first's field.
 func TestUpdateSettingAtomicInterleaving(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newSettingAtomicFixture(t)
 
 	entered := make(chan struct{})
@@ -149,6 +150,7 @@ func TestUpdateSettingAtomicInterleaving(t *testing.T) {
 // transaction with no write, leaves the cache untouched, and surfaces
 // unwrapped so callers keep typed errors.
 func TestUpdateSettingAtomicApplyAbort(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newSettingAtomicFixture(t)
 
 	sentinel := errors.New("validation failed")
@@ -176,6 +178,7 @@ func TestUpdateSettingAtomicApplyAbort(t *testing.T) {
 // TestUpdateSettingAtomicMissingRow pins that a missing setting row is an
 // error, not a silent create — the primitive updates existing state only.
 func TestUpdateSettingAtomicMissingRow(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newSettingAtomicFixture(t)
 
 	_, err := s.UpdateSettingAtomic(ctx, "default", storepb.SettingName_AI,
@@ -194,6 +197,7 @@ func TestUpdateSettingAtomicMissingRow(t *testing.T) {
 // implementation whose commit releases the row lock before an unordered cache
 // write.
 func TestUpdateSettingAtomicPublishOrder(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newSettingAtomicFixture(t)
 
 	pauseFirst := make(chan struct{})
@@ -319,6 +323,7 @@ func TestUpdateSettingAtomicPublishOrder(t *testing.T) {
 // cache a pre-commit snapshot after a newer value was already published.
 // Uncached readers must leave publication to the ordered paths.
 func TestSettingCacheNoFillFromUncachedReads(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newSettingAtomicFixture(t)
 	// Drop the seed's cache entry so the next cached read must fill.
 	s.DeleteCache()
@@ -346,6 +351,7 @@ func TestSettingCacheNoFillFromUncachedReads(t *testing.T) {
 // setting read in an HA process serializes behind a single lock, including
 // while a writer sits in its commit-to-publish window.
 func TestGetSettingCacheDisabledNotSerialized(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newSettingAtomicFixtureWithCache(t, false)
 
 	pause := make(chan struct{})
@@ -410,6 +416,7 @@ func TestGetSettingCacheDisabledNotSerialized(t *testing.T) {
 // request context — the canceled read was swallowed and postCommit silently
 // skipped, leaving derived runtime state diverged from the database forever.
 func TestUpdateSettingAtomicPublishSurvivesCancellation(t *testing.T) {
+	t.Parallel()
 	ctx, _, s := newSettingAtomicFixture(t)
 
 	updateCtx, cancel := context.WithCancel(ctx)
@@ -453,6 +460,7 @@ func TestUpdateSettingAtomicPublishSurvivesCancellation(t *testing.T) {
 // decodes to nothing — and the unfiltered list is how the settings API serves
 // every other setting, so one unreadable row must not take them all down.
 func TestListSettingsSkipsNamesThisBuildDoesNotKnow(t *testing.T) {
+	t.Parallel()
 	ctx, db, s := newSettingAtomicFixture(t)
 
 	// Inserted by hand because the point is a name this build's enum cannot
@@ -488,6 +496,7 @@ func TestListSettingsSkipsNamesThisBuildDoesNotKnow(t *testing.T) {
 // enforcement would then run one policy while the console showed another. That
 // is BOT-100's defect widened to every setting.
 func TestListSettingsRefusesAnUnparsedRow(t *testing.T) {
+	t.Parallel()
 	// Cache off: the fixture's own write would otherwise serve every read from
 	// memory, and the point is what the database hands back.
 	ctx, db, s := newSettingAtomicFixtureWithCache(t, false)
@@ -514,6 +523,7 @@ func TestListSettingsRefusesAnUnparsedRow(t *testing.T) {
 // WorkspaceProfileSetting with the signup settings, password restrictions and
 // announcements erased.
 func TestUpdateSettingAtomicRefusesAnUnparsedRow(t *testing.T) {
+	t.Parallel()
 	// Cache off: the point is what the locked row hands the writer.
 	ctx, db, s := newSettingAtomicFixtureWithCache(t, false)
 

--- a/backend/store/task_run_batch_test.go
+++ b/backend/store/task_run_batch_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestCreatePendingTaskRunsRejectsMultipleProjects(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/backend/store/task_run_claim_test.go
+++ b/backend/store/task_run_claim_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestClaimAvailableTaskRunsSkipsDeletedProjects(t *testing.T) {
+	t.Parallel()
 	fixture := newStorePostgresFixture(t, `
 		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
 		INSERT INTO plan (id, creator, project, name, description)
@@ -40,6 +41,7 @@ func TestClaimAvailableTaskRunsSkipsDeletedProjects(t *testing.T) {
 }
 
 func TestClaimAvailableTaskRunsSkipsArchivedInstances(t *testing.T) {
+	t.Parallel()
 	fixture := newTaskRunClaimFixture(t, `
 		INSERT INTO instance (resource_id, workspace, deleted) VALUES ('instance-a', 'default', TRUE);
 		INSERT INTO plan (id, creator, project, name, description)
@@ -68,6 +70,7 @@ func TestClaimAvailableTaskRunsSkipsArchivedInstances(t *testing.T) {
 }
 
 func TestClaimAvailableTaskRunsClaimsLiveInstanceSpecialTaskTypes(t *testing.T) {
+	t.Parallel()
 	fixture := newTaskRunClaimFixture(t, `
 		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
 		INSERT INTO plan (id, creator, project, name, description)

--- a/backend/store/task_run_pagination_test.go
+++ b/backend/store/task_run_pagination_test.go
@@ -18,6 +18,7 @@ import (
 // exactly once across pages even when another project's ids collide, and the
 // cross-project runner list keeps the same total order.
 func TestListTaskRunsPagination(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/backend/store/vcs_provider_user_test.go
+++ b/backend/store/vcs_provider_user_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestVCSProviderUserTouchAndCount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s, db := setupVCSProviderUserStore(ctx, t)
 
@@ -69,6 +70,7 @@ func TestVCSProviderUserTouchAndCount(t *testing.T) {
 }
 
 func TestVCSProviderUserInactiveUsersDoNotCountAndLimitRejectionKeepsRows(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s, db := setupVCSProviderUserStore(ctx, t)
 
@@ -136,6 +138,7 @@ func TestVCSProviderUserInactiveUsersDoNotCountAndLimitRejectionKeepsRows(t *tes
 }
 
 func TestVCSProviderUserTouchInactiveUserWhenUnderLimit(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s, db := setupVCSProviderUserStore(ctx, t)
 
@@ -165,6 +168,7 @@ func TestVCSProviderUserTouchInactiveUserWhenUnderLimit(t *testing.T) {
 }
 
 func TestVCSProviderUserListActiveUsersSortedDesc(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s, db := setupVCSProviderUserStore(ctx, t)
 
@@ -187,6 +191,7 @@ func TestVCSProviderUserListActiveUsersSortedDesc(t *testing.T) {
 }
 
 func TestVCSProviderUserTouchStoresEmptyPayloadWhenNil(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s, _ := setupVCSProviderUserStore(ctx, t)
 
@@ -207,6 +212,7 @@ func TestVCSProviderUserTouchStoresEmptyPayloadWhenNil(t *testing.T) {
 }
 
 func TestDeleteExpiredVCSProviderUsers(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	s, db := setupVCSProviderUserStore(ctx, t)
 

--- a/backend/store/workload_identity_test.go
+++ b/backend/store/workload_identity_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestWorkloadIdentityMessageConfig(t *testing.T) {
+	t.Parallel()
 	config := &storepb.WorkloadIdentityConfig{
 		ProviderType:     storepb.WorkloadIdentityConfig_GITHUB,
 		IssuerUrl:        "https://token.actions.githubusercontent.com",
@@ -27,6 +28,7 @@ func TestWorkloadIdentityMessageConfig(t *testing.T) {
 }
 
 func TestCreateWorkloadIdentityMessageConfig(t *testing.T) {
+	t.Parallel()
 	create := &CreateWorkloadIdentityMessage{
 		Email: "test@workload.bytebase.com",
 		Name:  "test",
@@ -45,6 +47,7 @@ func TestCreateWorkloadIdentityMessageConfig(t *testing.T) {
 }
 
 func TestUpdateWorkloadIdentityMessageConfig(t *testing.T) {
+	t.Parallel()
 	patch := &UpdateWorkloadIdentityMessage{
 		Config: &storepb.WorkloadIdentityConfig{
 			ProviderType:     storepb.WorkloadIdentityConfig_GITHUB,

--- a/backend/store/workspace_test.go
+++ b/backend/store/workspace_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestCreateWorkspaceInitializesDefaults(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	_, stores, _ := testcontainer.NewMetadataDB(t)
 
@@ -73,6 +74,7 @@ func TestCreateWorkspaceInitializesDefaults(t *testing.T) {
 }
 
 func TestListWorkspacesByEmailEvaluatesBindingConditions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	db, stores, _ := testcontainer.NewMetadataDB(t)
 

--- a/docs/design/backend-test-execution-time.md
+++ b/docs/design/backend-test-execution-time.md
@@ -81,19 +81,21 @@ constant — it will drift as package times change.
 `backend/tests` at 635 s is the slowest package. Fixing the four serial packages
 makes the run floor-bound on it almost immediately, so everything after that has
 to come out of `backend/tests` itself. Working through the efforts below should
-land the local pass around 6 minutes.
+land the local pass around 7.5 minutes.
 
 ## Design
 
-Seven efforts, ordered by payoff per unit of work.
+Six efforts, ordered by payoff per unit of work. Two have moved since this was
+written, and the numbering is kept through both so existing references resolve:
+effort 3 — a checkout pool for the 104 `provisionPgInstance` callers — is
+dropped, and effort 6 was rescoped and now runs ahead of effort 2 for `api/v1`.
 
-Efforts 1, 3, 4 and 5 all target `backend/tests`. Their figures are fixture
-cost inside a package that runs 3.7× parallel, and effort 1's saving sits inside
+Efforts 1, 4 and 5 all target `backend/tests`. Their figures are fixture cost
+inside a package that runs 3.7× parallel, and effort 1's saving sits inside
 effort 4's, so they do not simply add. Together they should take it from 635 s
-of wall clock to roughly 330 s.
-
-Effort 6 was rescoped and now runs ahead of effort 2 for `api/v1`; the numbering
-is kept so existing references resolve.
+of wall clock to roughly 450 s: dropping effort 3 leaves its 450 s of container
+time in place, which is about 120 s of wall at that compression, on top of the
+330 s the four efforts were originally worth.
 
 ### [✓] 1. Close idle connections before shutting the server down
 
@@ -125,15 +127,15 @@ went from **679 s to 611 s** across its 233 boots: 227 s off the summed test
 time, compressed 3.3× by the package's own parallelism. Measure the efforts
 below against 611 s.
 
-### [✓ step 1, store] 2. One shared container per package, then turn parallelism on
+### [✓] 2. One shared container per package, then turn parallelism on
 
 **459 s of wall clock, 390 s of it container starts.** `store` starts 90
 containers, and because it runs serially that cost is its wall clock almost
 exactly.
 
 `api/v1`, `component/review` and `migrator` were in this effort's original
-scope. AGENTS.md now confines a real metadata Postgres to `store` and `tests`,
-so all three move to effort 6 instead.
+scope. Effort 5 confines a real metadata Postgres to `store` and `tests`, so all
+three move to effort 6 instead.
 
 Two changes, in this order:
 
@@ -175,40 +177,33 @@ roughly 1.3 GB — but they live inside the package's own container, which
 each database costs about 54 ms, or 7 s across the package, to reclaim disk that
 is already reclaimed.
 
-**Step 2 is not done.** Nothing calls `t.Parallel()` yet, so this is step 1
-alone. Two things that would have blocked it are already checked: Postgres
-advisory locks are per-database, so the lock and claim tests cannot reach each
-other across per-test databases, and eight concurrent
-`CREATE DATABASE … TEMPLATE` from one template all succeed.
+**What step 2 bought, measured on one Linux box (20 vCPU), same tests both
+sides.** `t.Parallel()` on all 139 tests took `backend/store` from **16.2 s to
+10.9 s**, means of runs spanning 16.0–16.3 and 10.8–10.9. Those are not the
+12.0 s above; that was the Mac. Two things that would have blocked this were
+checked first and held: Postgres advisory locks are per-database, so the lock and
+claim tests cannot reach each other across per-test databases, and eight
+concurrent `CREATE DATABASE … TEMPLATE` from one template all succeed.
 
-### 3. Pool the provisioned Postgres instances
+**What is left is nearly all floor.** The package costs 1.3 s with no container
+at all and 6.9 s for a single test that needs one, so 5.6 s of the 10.9 s is the
+one container start and template migration that every test now queues behind
+inside `metaOnce`. Subtracting that 6.9 s from each side, the 138 other tests'
+own work went from 9.3 s to 4.0 s. Nothing further is worth spending here: the
+next second has to come off the container, not off the tests.
 
-**450 s of fixture time inside `backend/tests`.** 104 of its tests call
-`provisionPgInstance` to get a managed instance for Bytebase to point at, and
-each one is a fresh container.
+**Nine tests keep serial subtests, and two of them give up top-level parallelism
+for it.** `TestAuditLogRetentionFilteringEndToEnd` sets one workspace license row
+per subtest and reads it back, and `TestLoginAttemptClaim`'s purge subtest
+asserts a table-wide delete count that only holds while nothing else writes the
+table; both carry a comment saying so. The other seven parallelize at both levels
+because their subtests are keyed apart — distinct identities, codes, token
+hashes — or take a database each. `tparallel` enforces all-or-nothing per test,
+which is why those two go serial rather than parallel with serial subtests.
 
-Most of these tests only need an instance to exist and to hold their own
-databases, which they already create. Those can borrow from a pool of about 8
-long-lived containers and take a database each, leaving about 35 s.
-
-Ten files are the exception: they call `UpdateInstance`, `DeleteInstance` or a
-data-source mutation, so a shared instance would break for everyone else. The
-pool needs checkout semantics — borrow a shared instance by default, take an
-exclusive one when the test mutates instance config:
-
-```
-project_instance_test.go   project_instance_iam_collision_test.go
-project_instance_archive_task_run_test.go   cross_project_delete_test.go
-plan_update_test.go   data_source_test.go   sql_query_data_source_test.go
-sql_export_data_source_test.go   instance_keytab_retention_test.go
-mcp_forbidden_credential_mints_test.go
-```
-
-There is one place to fix this because `backend/tests` is the only package that
-starts a Bytebase server — `server.NewServer` has exactly two call sites, the
-real binary and `backend/tests/tests.go`. Keep it that way. A server-starting
-test elsewhere would need its own workspace scaffolding and its own instance
-pool, and would put a second package on the critical path.
+Peak concurrent connections to the shared container is 38 against Postgres's
+default 100, at `-parallel=20`. A runner with many more cores should have that
+re-measured before it is trusted.
 
 ### 4. Isolate per project, not per workspace
 
@@ -243,12 +238,20 @@ each test grants to its own principal.
 `TestWebhookIntegration` needs separate attention: 144 s, the slowest test in
 the repo, 24 subtests behind one boot with several fixed sleeps.
 
-### 5. Postgres only for API and workflow tests
+### 5. Postgres only for `backend/store` and `backend/tests`
 
 **Up to 320 s inside `backend/tests`**, of which 115 s is container starts and
 the rest is the duplicated test bodies. `TestSQLReviewForMySQL` costs 52.7 s
-where `TestSQLReviewForPostgreSQL` costs 17.9 s for the same assertion. The rule
-is now in the root `AGENTS.md`.
+where `TestSQLReviewForPostgreSQL` costs 17.9 s for the same assertion.
+
+Two packages may hold a real database, and no others. `backend/store` is where a
+metadata query is asserted against one, and `backend/tests` is the only package
+that boots a server. Everywhere else — `api/v1` above all — the handler's
+decide-and-convert half is tested over a fake or over plain data, which is effort
+6; an API test does not earn a container by being an API test. Inside the two
+packages that keep one, the engine is Postgres: engine dialects and DDL fidelity
+belong in omni. The root `AGENTS.md` carries that second half of the rule today,
+in the words "test API and workflow behavior against Postgres only".
 
 `docker events` recorded 11 MySQL containers from `backend/tests`. The
 candidates, one container each:
@@ -278,7 +281,7 @@ Three keep their engine. Each needs a comment saying why:
 ### 6. Seams instead of containers
 
 **822 s of wall clock, 611 s of it container starts**, after `migrator` was
-settled by deletion below. AGENTS.md confines a real metadata Postgres to
+settled by deletion below. Effort 5 confines a real metadata Postgres to
 `store` and `tests`; `api/v1` and `component/review` are not on that list and
 start 141 containers between them. `backend/api/mcp` is the proof this is
 livable: 168 tests in 39.5 s, 16 of its 18 files containerless.


### PR DESCRIPTION
## What changed

Step 1 ([#21345](https://github.com/bytebase/bytebase/pull/21345)) gave `backend/store` one shared Postgres and a template database per test. This is step 2 of that effort: `t.Parallel()` on all 139 top-level tests.

Same tests, same machine (20 vCPU), means of 5 runs each side: **16.2s → 10.9s**.

## Why the rest is floor

The package costs 1.3s with no container at all, and 6.9s for a single test that needs one. So 5.6s of the remaining 10.9s is the one container start and template migration that every test now queues behind inside `metaOnce`. Subtracting that 6.9s from each side, the other 138 tests' own work went from **9.3s to 4.0s**.

The next second has to come off the container, not off the tests.

## How the subtests were handled

`tparallel` enforces all-or-nothing per test, so the 32 tests that have subtests were classified rather than blanket-converted:

- **22 pure table tests** (the CEL-to-SQL filter builders and friends) parallelize at both levels — no shared state at all.
- **7 database-backed tests** parallelize at both levels because their subtests are keyed apart — distinct identities, codes, token hashes — or take a database each (`saved_query_lock_order_test.go` already built a fixture per subtest).
- **2 give up top-level parallelism instead**, and carry a comment saying why:
  - `TestAuditLogRetentionFilteringEndToEnd` sets one workspace license row per subtest and reads it back, so its subtests share a mutable row and have to run in order.
  - `TestLoginAttemptClaim`'s purge subtest asserts a table-wide delete count, which only holds while nothing else is writing `login_attempt`.

## Testing

- `go test ./backend/store/` — 11 clean runs, plus `-count=3` and `-race`.
- `-count=20` over the newly parallel concurrency tests (`TestCreateDraftAndRolloutAreSerialized`, `TestOAuth2AtomicConsume`, `TestSendBudgetClaim`, the saved-query lock-order pair, and the rest).
- `golangci-lint run ./backend/store/...` — 0 issues (`tparallel` included).
- Collision gate `go test ./backend/tests/ -run "^(TestClaim|TestCollision)"` — 2 clean runs.

**Reviewer note on connection headroom:** peak concurrent connections to the shared container is 38 against Postgres's default `max_connections=100`, measured at `-parallel=20`. `-parallel` defaults to `GOMAXPROCS`, so a runner with many more cores would want that re-measured before it is trusted. Recorded in the design doc.

## Design doc

`docs/design/backend-test-execution-time.md` follows the code:

- **Effort 3 dropped** — the checkout pool for the 104 `provisionPgInstance` callers. The totals it fed are redone: `backend/tests` now projects to roughly 450s rather than 330s, because that 450s of container time stays in place, which is about 120s of wall at the package's 3.7× compression. The local-pass target moves from 6 to 7.5 minutes. Numbering is kept so existing references resolve.
- **Effort 5 retitled** to "Postgres only for `backend/store` and `backend/tests`" — naming the two packages that may hold a real database rather than saying "API tests", since `api/v1` should be asserting over a fake. That is effort 6.
- Efforts 2 and 6 credited that rule to `AGENTS.md`, which does not carry it in those words (`AGENTS.md` still says "everything else asserts in `backend/api/v1` or `backend/store`"). Both now point at effort 5 instead. **Tightening `AGENTS.md` to match is deliberately left out of this PR** — say the word if you want it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)