### PR TITLE
fix(taskrun): give each task run scheduler its own tickle channel

### DIFF
--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -336,8 +336,8 @@ func (s *RolloutService) CreateRollout(ctx context.Context, req *connect.Request
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to rollout"))
 	}
 
-	// Tickle task run scheduler.
-	s.bus.TaskRunTickleChan <- 0
+	// Tickle the pending task run scheduler.
+	bus.Tickle(s.bus.TaskRunPendingTickleChan)
 
 	return connect.NewResponse(rolloutV1), nil
 }
@@ -930,8 +930,8 @@ func (s *RolloutService) BatchRunTasks(ctx context.Context, req *connect.Request
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create pending task runs, error %v", err))
 	}
 
-	// Tickle task run scheduler.
-	s.bus.TaskRunTickleChan <- 0
+	// Tickle the pending task run scheduler.
+	bus.Tickle(s.bus.TaskRunPendingTickleChan)
 
 	return connect.NewResponse(&v1pb.BatchRunTasksResponse{}), nil
 }

--- a/backend/component/bus/bus.go
+++ b/backend/component/bus/bus.go
@@ -44,8 +44,18 @@ type Bus struct {
 
 	// PlanCheckTickleChan is the tickler for plan check scheduler.
 	PlanCheckTickleChan chan int
-	// TaskRunTickleChan is the tickler for task run scheduler.
-	TaskRunTickleChan chan int
+	// TaskRunPendingTickleChan is the tickler for the pending task run
+	// scheduler: a task run was created and needs scheduling.
+	TaskRunPendingTickleChan chan int
+	// TaskRunRunningTickleChan is the tickler for the running task run
+	// scheduler: a task run became available and needs to be picked up.
+	//
+	// The two task run schedulers must not share one channel. A channel value is
+	// delivered to exactly one receiver, so a shared channel hands each wake-up
+	// to whichever scheduler happens to be ready for it rather than to the one
+	// the sender meant, and the scheduler that actually had work waits out its
+	// 5s ticker instead. That cost a measured ~5s per task run transition.
+	TaskRunRunningTickleChan chan int
 	// ReviewRunTickleChan is the tickler for the review run scheduler.
 	ReviewRunTickleChan chan int
 
@@ -58,11 +68,23 @@ type Bus struct {
 
 func New() (*Bus, error) {
 	return &Bus{
-		ApprovalCheckChan:       make(chan IssueRef, 1000),
-		PlanCheckTickleChan:     make(chan int, 1000),
-		TaskRunTickleChan:       make(chan int, 1000),
-		ReviewRunTickleChan:     make(chan int, 1000),
-		RolloutCreationChan:     make(chan PlanRef, 100),
-		PlanCompletionCheckChan: make(chan PlanRef, 1000),
+		ApprovalCheckChan:        make(chan IssueRef, 1000),
+		PlanCheckTickleChan:      make(chan int, 1000),
+		TaskRunPendingTickleChan: make(chan int, 1000),
+		TaskRunRunningTickleChan: make(chan int, 1000),
+		ReviewRunTickleChan:      make(chan int, 1000),
+		RolloutCreationChan:      make(chan PlanRef, 100),
+		PlanCompletionCheckChan:  make(chan PlanRef, 1000),
 	}, nil
+}
+
+// Tickle wakes a scheduler without blocking. A tickle carries no information
+// beyond "there may be work"; every scheduler sweeps the store for all of it,
+// so a wake-up already queued makes another redundant. Not blocking here also
+// keeps a request handler from parking on a scheduler that has stopped reading.
+func Tickle(ch chan int) {
+	select {
+	case ch <- 0:
+	default:
+	}
 }

--- a/backend/runner/taskrun/pending_scheduler.go
+++ b/backend/runner/taskrun/pending_scheduler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/component/productmetrics"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/store"
@@ -40,7 +41,7 @@ func (s *Scheduler) runPendingTaskRunsScheduler(ctx context.Context, wg *sync.Wa
 			if err := s.schedulePendingTaskRuns(ctx); err != nil {
 				slog.Error("failed to schedule pending task runs", log.BBError(err))
 			}
-		case <-s.bus.TaskRunTickleChan:
+		case <-s.bus.TaskRunPendingTickleChan:
 			if err := s.licenseService.CheckReplicaLimit(ctx); err != nil {
 				// Grace period is tracked by the ticker branch; just skip here.
 				continue
@@ -247,10 +248,9 @@ func (s *Scheduler) promoteTaskRun(ctx context.Context, taskRun *store.TaskRunMe
 		return errors.Wrapf(err, "failed to update task run status to available")
 	}
 
-	select {
-	case s.bus.TaskRunTickleChan <- 0:
-	default:
-	}
+	// The task run is available now, which is the running scheduler's business,
+	// not this one's.
+	bus.Tickle(s.bus.TaskRunRunningTickleChan)
 
 	return nil
 }

--- a/backend/runner/taskrun/rollout_creator.go
+++ b/backend/runner/taskrun/rollout_creator.go
@@ -205,8 +205,8 @@ func (rc *RolloutCreator) tryCreateRollout(ctx context.Context, ref bus.PlanRef)
 		return
 	}
 
-	// Tickle task run scheduler
-	rc.bus.TaskRunTickleChan <- 0
+	// Tickle the pending task run scheduler.
+	bus.Tickle(rc.bus.TaskRunPendingTickleChan)
 
 	slog.Info("successfully auto-created rollout", slog.String("project", ref.ProjectID), slog.Int("plan_id", int(planID)))
 }

--- a/backend/runner/taskrun/rollout_creator_test.go
+++ b/backend/runner/taskrun/rollout_creator_test.go
@@ -120,7 +120,7 @@ func TestTryCreateRolloutSkipsDraft(t *testing.T) {
 	require.NotNil(t, gotIssue)
 	require.True(t, gotIssue.Payload.GetDraft())
 	require.Equal(t, storepb.Issue_OPEN, gotIssue.Status)
-	require.Empty(t, b.TaskRunTickleChan)
+	require.Empty(t, b.TaskRunPendingTickleChan)
 }
 
 func TestTryCreateRolloutSkipsArchivedProject(t *testing.T) {
@@ -204,7 +204,7 @@ func TestTryCreateRolloutSkipsArchivedProject(t *testing.T) {
 	tasks, err := s.ListTasks(ctx, &store.TaskFind{ProjectID: plan.ProjectID, PlanID: &plan.UID})
 	require.NoError(t, err)
 	require.Empty(t, tasks)
-	require.Empty(t, b.TaskRunTickleChan)
+	require.Empty(t, b.TaskRunPendingTickleChan)
 }
 
 func TestTryCreateRolloutResolvesProjectInstanceOutsideRequestContext(t *testing.T) {
@@ -277,7 +277,7 @@ func TestTryCreateRolloutResolvesProjectInstanceOutsideRequestContext(t *testing
 	tasks, err := s.ListTasks(ctx, &store.TaskFind{ProjectID: projectID, PlanID: &plan.UID})
 	require.NoError(t, err)
 	require.Len(t, tasks, 1)
-	require.Len(t, b.TaskRunTickleChan, 1)
+	require.Len(t, b.TaskRunPendingTickleChan, 1)
 }
 
 func TestTryCreateRolloutRejectsArchivedProjectInstanceWithWarmDatabaseCache(t *testing.T) {
@@ -367,7 +367,7 @@ func TestTryCreateRolloutRejectsArchivedProjectInstanceWithWarmDatabaseCache(t *
 	tasks, err := s.ListTasks(ctx, &store.TaskFind{ProjectID: projectID, PlanID: &plan.UID})
 	require.NoError(t, err)
 	require.Empty(t, tasks)
-	require.Empty(t, b.TaskRunTickleChan)
+	require.Empty(t, b.TaskRunPendingTickleChan)
 }
 
 func setupRolloutCreatorStore(ctx context.Context, t *testing.T) *store.Store {

--- a/backend/runner/taskrun/running_scheduler.go
+++ b/backend/runner/taskrun/running_scheduler.go
@@ -38,7 +38,7 @@ func (s *Scheduler) runRunningTaskRunsScheduler(ctx context.Context, wg *sync.Wa
 			if err := s.scheduleRunningTaskRuns(ctx); err != nil {
 				slog.Error("failed to schedule running task runs", log.BBError(err))
 			}
-		case <-s.bus.TaskRunTickleChan:
+		case <-s.bus.TaskRunRunningTickleChan:
 			if err := s.licenseService.CheckReplicaLimit(ctx); err != nil {
 				continue
 			}


### PR DESCRIPTION
## The bug

The pending and running task run schedulers both received from one channel:

```go
pending_scheduler.go:43   case <-s.bus.TaskRunTickleChan:
running_scheduler.go:41   case <-s.bus.TaskRunTickleChan:
```

A Go channel value is delivered to **exactly one** receiver. So each wake-up went to whichever scheduler happened to be ready for it rather than to the one the sender meant. When it went to the wrong one, that scheduler found nothing to do — and the scheduler that actually had work waited out its `taskSchedulerInterval = 5 * time.Second` ticker.

The clearest case is `promoteTaskRun`: the pending scheduler marks a task run *available* and tickles specifically to wake the **running** scheduler, and the shared channel could hand that wake-up straight back to itself.

The buffer size (1000) is irrelevant here — this is not a dropped send, it's a misrouted one.

**This is a production latency bug, not a test artifact.** Every task run transition had a coin-flip chance of stalling ~5 s, so a real user's rollout stalls for a multiple of that.

## The fix

Split the channel in two and route each producer to the scheduler it actually has work for:

| Producer | Wakes |
|---|---|
| `CreateRollout` | pending |
| `BatchRunTasks` → `CreatePendingTaskRuns` | pending |
| auto rollout creator | pending |
| `promoteTaskRun` (run became available) | **running** |

Routing precisely was verified to measure identically to waking both schedulers — which also demonstrates the API paths never needed the running scheduler, so this adds no scheduler load.

## Evidence

Instrumenting one subtest showed everything the test does is instant and all the time sits in `createDatabase`, which was bimodal across repeat runs — either 0.93 s or 4.8–5.7 s, clustering exactly on the 5 s ticker. 8 of 10 paid a full tick.

| | Before | After |
|---|---:|---:|
| `createDatabase` | 0.93 s **or** 4.8 s | **0.93 s, every run** |
| `TestWebhookIntegration` | 154 s | **39.5 s** |
| `backend/tests` (this branch, off main) | 614.7 s | **331.7 s** |
| `backend/tests` (with #21354 as well) | 614.7 s | **115.8 s** |

## One judgement call worth reviewing

The three blocking sends (`s.bus.TaskRunTickleChan <- 0`) become a non-blocking `bus.Tickle()` helper — the pattern `promoteTaskRun` already used. A tickle carries no payload; every scheduler sweeps the store for all work, so a wake-up already queued makes another redundant. Not blocking also keeps a request handler from parking on a scheduler that has stopped reading.

It's adjacent to the core fix rather than required by it — happy to drop it if you'd rather keep the diff minimal.

## Testing

- `./backend/runner/taskrun/...`, `./backend/component/bus/...`, `./backend/api/v1/...` — all pass. `rollout_creator_test.go`'s four channel assertions are updated to the renamed field.
- `TestWebhookIntegration` and full `backend/tests` — pass.
- `golangci-lint run` — no new issues (the one reported, `backend/common/cel_filter.go` package-naming, is pre-existing on main and untouched here).
- Server build OK.

## Note on what this changes downstream

After this, `TestWebhookIntegration` is no longer the slowest test in the backend suite — `TestSQLReviewForMySQL` (51 s) is, which is the duplicated-MySQL-body cleanup already tracked in `docs/design/backend-test-execution-time.md` as effort 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)