### PR TITLE
Remove TiDB Docker Compose configuration

### DIFF
--- a/docker/tidb.yaml
+++ b/docker/tidb.yaml
@@ -1,6 +1,0 @@
-services:
-  tidb:
-    image: pingcap/tidb:v8.5.5
-    container_name: tidb-test
-    ports:
-      - "4000:4000"


### PR DESCRIPTION
## Summary

Delete `docker/tidb.yaml`, an unused Docker Compose service definition (`pingcap/tidb:v8.5.5`, port 4000). It was the only file under `docker/`, so that directory goes away with it.

## Rationale

It is dead weight, not part of any workflow:

- Nothing in the repo references the file, and the repo has no Docker Compose workflow at all — `docker compose` / `docker-compose` appears in zero files (CI, scripts, Makefile, docs).
- TiDB tests don't need it: `testcontainer.GetTiDBContainer` (`backend/common/testcontainer/testcontainer.go`) starts a TiDB container programmatically via testcontainers.
- It was committed incidentally in #21302 — a leftover from manually validating parser behavior against `pingcap/tidb:v8.5.5`, as the comment above `TestGenerateRestoreSQLSelfJoinMixedCaseAlias` in `backend/plugin/parser/tidb/restore_test.go` describes.

## Testing

Deletion-only, no code paths touched. Verified by grepping the whole tree for references to the file, to the `docker/` directory, and to Compose usage — no hits outside the file itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUKag4uiXhJ1KaiCFSZkU5