### PR TITLE
fix: satisfy Cloud SQL sample password complexity

### DIFF
--- a/backend/component/sample/saas/manager.go
+++ b/backend/component/sample/saas/manager.go
@@ -538,7 +538,8 @@ func randomPassword(reader io.Reader) (string, error) {
 	if _, err := io.ReadFull(reader, value); err != nil {
 		return "", err
 	}
-	return base64.RawURLEncoding.EncodeToString(value), nil
+	// Satisfy Cloud SQL password complexity without reducing the random entropy.
+	return "Aa0!" + base64.RawURLEncoding.EncodeToString(value), nil
 }
 
 func randomInstanceID(reader io.Reader) (string, error) {

--- a/backend/component/sample/saas/manager_test.go
+++ b/backend/component/sample/saas/manager_test.go
@@ -1,13 +1,38 @@
 package saas
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"testing"
+	"unicode"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/component/sample"
 )
+
+func TestRandomPasswordMeetsCloudSQLComplexity(t *testing.T) {
+	for _, value := range []byte{0, 0xff, 'x'} {
+		password, err := randomPassword(bytes.NewReader(bytes.Repeat([]byte{value}, 32)))
+		require.NoError(t, err)
+		var lower, upper, digit, symbol bool
+		for _, char := range password {
+			lower = lower || unicode.IsLower(char)
+			upper = upper || unicode.IsUpper(char)
+			digit = digit || unicode.IsDigit(char)
+			symbol = symbol || (!unicode.IsLetter(char) && !unicode.IsDigit(char))
+		}
+		require.True(t, lower && upper && digit && symbol, "password must satisfy Cloud SQL complexity for input byte %d", value)
+		require.GreaterOrEqual(t, len(password), 43)
+	}
+}
+
+func TestRandomPasswordRequiresFullEntropy(t *testing.T) {
+	password, err := randomPassword(bytes.NewReader(make([]byte, 31)))
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Empty(t, password)
+}
 
 func TestCheckAvailableRejectsUnconfiguredManager(t *testing.T) {
 	var manager *Manager


### PR DESCRIPTION
Cloud SQL rejects sample role creation when the generated Base64 password omits a required character category, causing intermittent `failed to create sample project instance role` errors. Production logs confirmed password-complexity rejections; a deterministic probe of the old generator failed the policy for roughly 26% of passwords.

Prefix generated passwords with `Aa0!` to guarantee lowercase, uppercase, numeric, and non-alphanumeric characters while retaining all 32 cryptographically random bytes. Add regression coverage for inputs missing required categories and incomplete entropy reads. No infrastructure policy changes are needed.

Validation:
- Regression test failed before the fix and passed afterward.
- `go test ./backend/component/sample/... -count=1`
- `golangci-lint run --allow-parallel-runners` and `golangci-lint run --fix --allow-parallel-runners`: zero issues.
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

Pre-PR checklist reviewed: no breaking changes; metadata query, pagination, transaction, and image compatibility checks do not apply.
