### PR TITLE
fix(frontend): unify create database labels

### DIFF
--- a/frontend/src/components/database/CreateDatabaseSheet.test.tsx
+++ b/frontend/src/components/database/CreateDatabaseSheet.test.tsx
@@ -602,7 +602,7 @@ describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
 
     const titleInput = getTitleInput();
     expect(titleInput).toBeTruthy();
-    expect(titleInput.value).toBe("quick-action.create-db 'widgets'");
+    expect(titleInput.value).toBe("database.create-database 'widgets'");
   });
 
   it("does not auto-fill title when enforceIssueTitle is true", async () => {
@@ -628,7 +628,7 @@ describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
     await fillInstance();
     await fillDatabaseName("widgets");
     await flush();
-    expect(getTitleInput().value).toBe("quick-action.create-db 'widgets'");
+    expect(getTitleInput().value).toBe("database.create-database 'widgets'");
 
     // Step 1: type a custom title.
     await act(async () => {
@@ -650,13 +650,13 @@ describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
     // Step 5: retype dbName and verify each keystroke tracks.
     await fillDatabaseName("f");
     await flush();
-    expect(getTitleInput().value).toBe("quick-action.create-db 'f'");
+    expect(getTitleInput().value).toBe("database.create-database 'f'");
     await fillDatabaseName("fo");
     await flush();
-    expect(getTitleInput().value).toBe("quick-action.create-db 'fo'");
+    expect(getTitleInput().value).toBe("database.create-database 'fo'");
     await fillDatabaseName("foo");
     await flush();
-    expect(getTitleInput().value).toBe("quick-action.create-db 'foo'");
+    expect(getTitleInput().value).toBe("database.create-database 'foo'");
   });
 
   it("clears the auto-filled title when the database name is cleared (BYT-9310 stale-ghost fix)", async () => {
@@ -668,7 +668,7 @@ describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
     await fillInstance();
     await fillDatabaseName("widgets");
     await flush();
-    expect(getTitleInput().value).toBe("quick-action.create-db 'widgets'");
+    expect(getTitleInput().value).toBe("database.create-database 'widgets'");
 
     // Clear the database name.
     await fillDatabaseName("");
@@ -683,7 +683,7 @@ describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
     await fillDatabaseName("widgets");
     await flush();
 
-    expect(getTitleInput().value).toBe("quick-action.create-db 'widgets'");
+    expect(getTitleInput().value).toBe("database.create-database 'widgets'");
 
     await act(async () => {
       nativeChange(getTitleInput(), "my custom title");
@@ -854,7 +854,7 @@ describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
             id: expect.any(String),
           },
         ],
-        title: "quick-action.create-db 'widgets'",
+        title: "database.create-database 'widgets'",
       },
     });
     expect(mocks.createIssue).toHaveBeenCalledOnce();
@@ -864,7 +864,7 @@ describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
         draft: false,
         labels: ["required"],
         plan: "projects/foo/plans/123",
-        title: "quick-action.create-db 'widgets'",
+        title: "database.create-database 'widgets'",
         type: 1,
       },
       parent: "projects/foo",

--- a/frontend/src/components/database/CreateDatabaseSheet.tsx
+++ b/frontend/src/components/database/CreateDatabaseSheet.tsx
@@ -261,7 +261,7 @@ function CreateDatabaseForm({
     // doesn't retain a stale derivation from the prior keystroke (the
     // `Create database 'T'` ghost after the user backspaces to empty).
     setTitle(
-      databaseName ? `${t("quick-action.create-db")} '${databaseName}'` : ""
+      databaseName ? `${t("database.create-database")} '${databaseName}'` : ""
     );
   }, [databaseName, enforceIssueTitle, projectHydrated]);
 
@@ -398,7 +398,7 @@ function CreateDatabaseForm({
       });
       const effectiveTitle =
         normalizeTitle(title) ||
-        `${t("quick-action.create-db")} '${databaseName}'`;
+        `${t("database.create-database")} '${databaseName}'`;
       const planCreate = create(PlanSchema, {
         title: effectiveTitle,
         specs: [spec],
@@ -473,7 +473,7 @@ function CreateDatabaseForm({
   return (
     <>
       <SheetHeader>
-        <SheetTitle>{t("quick-action.create-db")}</SheetTitle>
+        <SheetTitle>{t("database.create-database")}</SheetTitle>
       </SheetHeader>
 
       <SheetBody>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1885,7 +1885,6 @@
     }
   },
   "project": {
-    "add-database": "Add database",
     "add-database-empty-placeholder": "Add a database in an existing instance to this project",
     "batch": {
       "archive": {
@@ -2109,7 +2108,6 @@
     }
   },
   "quick-action": {
-    "create-db": "Create database",
     "create-project": "Create project",
     "new-project": "New Project"
   },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1885,7 +1885,6 @@
     }
   },
   "project": {
-    "add-database": "Agregar base de datos",
     "add-database-empty-placeholder": "Agrega una base de datos de una instancia existente a este proyecto",
     "batch": {
       "archive": {
@@ -2109,7 +2108,6 @@
     }
   },
   "quick-action": {
-    "create-db": "Crear base de datos",
     "create-project": "Crear proyecto",
     "new-project": "Nuevo Proyecto"
   },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1885,7 +1885,6 @@
     }
   },
   "project": {
-    "add-database": "データベースを追加",
     "add-database-empty-placeholder": "既存のインスタンスのデータベースをこのプロジェクトに追加します",
     "batch": {
       "archive": {
@@ -2109,7 +2108,6 @@
     }
   },
   "quick-action": {
-    "create-db": "データベースの作成",
     "create-project": "プロジェクトを作成",
     "new-project": "作成するプロジェクト"
   },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1885,7 +1885,6 @@
     }
   },
   "project": {
-    "add-database": "Thêm cơ sở dữ liệu",
     "add-database-empty-placeholder": "Thêm cơ sở dữ liệu trong một phiên bản hiện có vào dự án này",
     "batch": {
       "archive": {
@@ -2109,7 +2108,6 @@
     }
   },
   "quick-action": {
-    "create-db": "Tạo cơ sở dữ liệu",
     "create-project": "Tạo dự án",
     "new-project": "Mới Dự án"
   },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1885,7 +1885,6 @@
     }
   },
   "project": {
-    "add-database": "添加数据库",
     "add-database-empty-placeholder": "将现有实例中的数据库添加到此项目",
     "batch": {
       "archive": {
@@ -2109,7 +2108,6 @@
     }
   },
   "quick-action": {
-    "create-db": "创建数据库",
     "create-project": "创建项目",
     "new-project": "创建项目"
   },

--- a/frontend/src/routes/project/ProjectDatabasesPage.test.tsx
+++ b/frontend/src/routes/project/ProjectDatabasesPage.test.tsx
@@ -387,7 +387,7 @@ describe("ProjectDatabasesPage", () => {
     });
   });
 
-  test("opens the add database sheet when the project is empty but the workspace has instances", async () => {
+  test("opens the create database sheet when the project is empty but the workspace has instances", async () => {
     mocks.fetchInstanceList.mockResolvedValueOnce({
       instances: [{ name: "instances/prod", title: "Prod" }],
     });
@@ -402,7 +402,7 @@ describe("ProjectDatabasesPage", () => {
     const button = container.querySelector(
       "button:not([data-product-intro-target])"
     ) as HTMLButtonElement;
-    expect(button.textContent?.trim()).toContain("project.add-database");
+    expect(button.textContent?.trim()).toContain("database.create-database");
     expect(container.textContent).toContain(
       "project.add-database-empty-placeholder"
     );
@@ -441,7 +441,7 @@ describe("ProjectDatabasesPage", () => {
 
     expect(mocks.fetchInstanceList).toHaveBeenCalledTimes(1);
     expect(mocks.fetchInstanceList).toHaveBeenCalledWith({ pageSize: 2 });
-    expect(container.textContent).toContain("project.add-database");
+    expect(container.textContent).toContain("database.create-database");
     expect(container.textContent).not.toContain("project.connect-instance");
 
     act(() => {
@@ -486,7 +486,7 @@ describe("ProjectDatabasesPage", () => {
     });
   });
 
-  test("opens the add database sheet when the project has a project instance", async () => {
+  test("opens the create database sheet when the project has a project instance", async () => {
     mocks.fetchInstanceList.mockImplementation(async (params) => ({
       instances:
         params?.parent === "projects/demo"
@@ -506,7 +506,7 @@ describe("ProjectDatabasesPage", () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain("project.add-database");
+    expect(container.textContent).toContain("database.create-database");
     expect(container.textContent).not.toContain("project.connect-database");
     expect(mocks.fetchInstanceList).toHaveBeenCalledWith({
       parent: "projects/demo",
@@ -650,7 +650,7 @@ describe("ProjectDatabasesPage", () => {
       "db.project-instance-syncing-title"
     );
     const button = container.querySelector("button") as HTMLButtonElement;
-    expect(button.textContent?.trim()).toContain("project.add-database");
+    expect(button.textContent?.trim()).toContain("database.create-database");
 
     await act(async () => {
       button.click();

--- a/frontend/src/routes/project/ProjectDatabasesPage.tsx
+++ b/frontend/src/routes/project/ProjectDatabasesPage.tsx
@@ -697,7 +697,7 @@ export function ProjectDatabasesPage({ projectId }: { projectId: string }) {
               {hasVisibleDatabase
                 ? t("common.create")
                 : emptyProjectHasInstance
-                  ? t("project.add-database")
+                  ? t("database.create-database")
                   : t("project.connect-instance")}
             </Button>
           </PermissionGuard>


### PR DESCRIPTION
The empty project database page labeled the database creation action “Add database,” while the workspace page and creation drawer used “Create database.” Use `database.create-database` for all three surfaces and the drawer's generated issue titles.

Remove the two redundant translation keys from all five locales and update existing test expectations.

Validation: frontend formatting, checks, and type check passed; all 4,121 tests across 500 files passed. Pre-PR checklist completed; no breaking changes or backend query changes.
