### PR TITLE
fix(instance): show copyable Bytebase Cloud IP in connection form

### DIFF
--- a/frontend/src/components/instance/ConnectionRecovery.test.ts
+++ b/frontend/src/components/instance/ConnectionRecovery.test.ts
@@ -112,7 +112,7 @@ describe("ConnectionRecovery", () => {
     );
     expect(container.querySelector("a")).toHaveAttribute(
       "href",
-      "https://docs.bytebase.com/get-started/cloud#prerequisites"
+      "https://docs.bytebase.com/get-started/cloud#network-requirements"
     );
 
     act(() => root.unmount());

--- a/frontend/src/components/instance/ConnectionRecovery.tsx
+++ b/frontend/src/components/instance/ConnectionRecovery.tsx
@@ -136,7 +136,7 @@ export function ConnectionRecovery({
         className="mt-3 inline-flex items-center gap-x-1 text-sm font-medium underline underline-offset-2"
         href={
           isSaaSMode
-            ? "https://docs.bytebase.com/get-started/cloud#prerequisites"
+            ? "https://docs.bytebase.com/get-started/cloud#network-requirements"
             : "https://docs.bytebase.com/get-started/connect/overview?source=console"
         }
         target="_blank"

--- a/frontend/src/components/instance/InstanceFormBody.test.ts
+++ b/frontend/src/components/instance/InstanceFormBody.test.ts
@@ -170,7 +170,7 @@ describe("InstanceFormBody", () => {
     expect(firewallInfoIndex).toBeGreaterThan(connectionTitleIndex);
     expect(firewallInfoIndex).toBeLessThan(connectionGridIndex);
     expect(source).toContain(
-      'href="https://docs.bytebase.com/get-started/cloud#prerequisites"'
+      'href="https://docs.bytebase.com/get-started/cloud#network-requirements"'
     );
   });
 

--- a/frontend/src/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/components/instance/InstanceFormBody.tsx
@@ -20,6 +20,7 @@ import { RouterLink } from "@/components/RouterLink";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { CopyButton } from "@/components/ui/copy-button";
 import {
   FormControlGroup,
   FormControlRow,
@@ -73,6 +74,7 @@ import {
 import type { EditDataSource } from "./common";
 import { hasSslConfig } from "./common";
 import {
+  BYTEBASE_CLOUD_IP,
   MongoDBConnectionStringSchemaList,
   RedisConnectionType,
   SnowflakeExtraLinkPlaceHolder,
@@ -1447,14 +1449,14 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
           </h3>
           {isSaaSMode && (
             <Alert variant="info" className="mt-2">
-              <a
-                href="https://docs.bytebase.com/get-started/cloud#prerequisites"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="normal-link"
-              >
-                {t("instance.sentence.firewall-info")}
-              </a>
+              <p>{t("instance.sentence.firewall-info")}</p>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <code className="select-all font-mono">
+                  {BYTEBASE_CLOUD_IP}
+                </code>
+                <CopyButton content={BYTEBASE_CLOUD_IP} />
+                <LearnMoreLink href="https://docs.bytebase.com/get-started/cloud#network-requirements" />
+              </div>
             </Alert>
           )}
 

--- a/frontend/src/components/instance/constants.ts
+++ b/frontend/src/components/instance/constants.ts
@@ -1,6 +1,9 @@
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import { supportedEngineV1List } from "@/utils";
 
+// Keep in sync with https://docs.bytebase.com/get-started/cloud#network-requirements.
+export const BYTEBASE_CLOUD_IP = "34.27.188.162";
+
 export const defaultPortForEngine = (engine: Engine) => {
   switch (engine) {
     case Engine.CLICKHOUSE:


### PR DESCRIPTION
Creating an instance in Bytebase Cloud currently sends users to the documentation to find the IP they need for their database firewall. Display `34.27.188.162` directly in the connection notice with a copy button, and retain a secondary Learn more link. Update the form and connection-recovery links to the current network-requirements anchor.

Validation: frontend fix, check, type-check, and test passed (500 test files, 4,126 tests). Vitest reported a Vite shutdown timeout after successful tests; the command exited with code 0. The IP was verified against the official Cloud documentation.
