### PR TITLE
fix(schemasync): avoid nested metadata pool acquisition

### DIFF
--- a/backend/runner/schemasync/pool_test.go
+++ b/backend/runner/schemasync/pool_test.go
@@ -1,0 +1,79 @@
+package schemasync
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/component/dbfactory"
+	"github.com/bytebase/bytebase/backend/enterprise"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/db"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func init() {
+	db.Register(storepb.Engine_MYSQL, func() db.Driver { return &poolTestDriver{} })
+}
+
+// Only the target engine is stubbed; metadata reads and transactions use PostgreSQL.
+type poolTestDriver struct {
+	db.Driver
+}
+
+func (d *poolTestDriver) Open(context.Context, storepb.Engine, db.ConnectionConfig) (db.Driver, error) {
+	return d, nil
+}
+
+func (*poolTestDriver) Close(context.Context) error { return nil }
+
+func (*poolTestDriver) SyncDBSchema(context.Context) (*storepb.DatabaseSchemaMetadata, error) {
+	return &storepb.DatabaseSchemaMetadata{Name: "app"}, nil
+}
+
+func (*poolTestDriver) Dump(context.Context, io.Writer, *storepb.DatabaseSchemaMetadata) error {
+	return nil
+}
+
+func TestSyncDatabaseSchemaHoldsOnePoolConnection(t *testing.T) {
+	ctx := context.Background()
+	stores := setupSyncerStore(ctx, t)
+	_, err := stores.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "instance-a",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_MYSQL,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	database, err := stores.UpsertDatabase(ctx, &store.DatabaseMessage{
+		InstanceID: "instance-a", DatabaseName: "app", ProjectID: "project-a",
+		Metadata: &storepb.DatabaseMetadata{BackupAvailable: true},
+	})
+	require.NoError(t, err)
+	licenseService, err := enterprise.NewLicenseService(common.ReleaseModeDev, stores, false, "")
+	require.NoError(t, err)
+	syncer := NewSyncer(stores, dbfactory.New(stores, licenseService), licenseService, nil)
+
+	// An absent bbdataarchive forces the backup lookup to read the metadata DB.
+	// With one connection, a lookup inside UpdateDatabase's transaction cannot
+	// proceed. This models a sync burst occupying every pool slot (BYT-10184).
+	stores.GetDB().SetMaxOpenConns(1)
+	syncCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, syncer.SyncDatabaseSchema(syncCtx, database))
+
+	updated, err := stores.GetDatabase(ctx, &store.FindDatabaseMessage{
+		InstanceID: &database.InstanceID, DatabaseName: &database.DatabaseName,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.False(t, updated.Metadata.BackupAvailable)
+	require.Equal(t, storepb.SyncStatus_SYNC_STATUS_OK, updated.Metadata.SyncStatus)
+	require.NotNil(t, updated.Metadata.LastSyncTime)
+}

--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -595,11 +595,15 @@ func (s *Syncer) doSyncDatabaseSchema(ctx context.Context, database *store.Datab
 
 	dbConfig := dbMetadata.GetConfig()
 
+	// Resolve store reads before UpdateDatabase opens its write transaction.
+	// Acquiring another pool connection inside the callback can deadlock sync bursts.
+	backupAvailable := s.databaseBackupAvailable(ctx, instance, syncedDatabaseMetadata)
+
 	// Build metadata updates
 	metadataUpdates := []func(*storepb.DatabaseMetadata){
 		func(md *storepb.DatabaseMetadata) {
 			md.LastSyncTime = timestamppb.Now()
-			md.BackupAvailable = s.databaseBackupAvailable(ctx, instance, syncedDatabaseMetadata)
+			md.BackupAvailable = backupAvailable
 			md.Datashare = syncedDatabaseMetadata.Datashare
 			md.SyncStatus = storepb.SyncStatus_SYNC_STATUS_OK
 			md.SyncError = ""

--- a/backend/store/database.go
+++ b/backend/store/database.go
@@ -53,7 +53,9 @@ type UpdateDatabaseMessage struct {
 	ProjectID *string
 	Deleted   *bool
 	// Empty string will unset the environment.
-	EnvironmentID   *string
+	EnvironmentID *string
+	// MetadataUpdates run inside a write transaction. Callbacks must not acquire
+	// another store connection; compute any required store reads before UpdateDatabase.
 	MetadataUpdates []func(*storepb.DatabaseMetadata)
 }
 


### PR DESCRIPTION
Schema-sync bursts can exhaust the metadata connection pool because `UpdateDatabase` holds a transaction connection while its metadata callback requests another connection to check backup availability. Move that lookup before `UpdateDatabase` and document that metadata callbacks must not acquire another store connection.

Add `TestSyncDatabaseSchemaHoldsOnePoolConnection`, which runs the real schema-sync path against PostgreSQL with a one-connection metadata pool and a stubbed MySQL driver. It fails with a deadline exceeded before the fix and passes afterward, verifying persisted sync status and backup availability.

Fixes https://linear.app/bytebase/issue/BYT-10184

Validation:
- Regression test: RED before the fix, GREEN afterward.
- `go test -count=1 ./backend/runner/schemasync ./backend/store`
- `golangci-lint run --fix --allow-parallel-runners` and `golangci-lint run --allow-parallel-runners`: 0 issues.
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `git diff --check`
