### PR TITLE
chore(lint): drop dead golangci exclusions, pin local -j 8

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -116,12 +116,9 @@ linters:
         text: Exit(.*)_(.*)
       - path: action/bitbucket/bitbucket.go
         text: "unsecure-url-scheme.*http://api.bitbucket.org"
+    # Filters reported issues only; excluded paths are still analyzed. Not a speed knob.
     paths:
-      - proto/generated-go
-      - frontend
-      - third_party$
-      - builtin$
-      - examples$
+      - backend/generated-go
 formatters:
   enable:
     - goimports
@@ -132,8 +129,4 @@ formatters:
   exclusions:
     generated: lax
     paths:
-      - proto/generated-go
-      - frontend
-      - third_party$
-      - builtin$
-      - examples$
+      - backend/generated-go

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ During iteration, run focused checks for the changed behavior. Before handoff, r
 ### Go changes
 
 1. Run `gofmt -w` on modified Go files.
-2. Run `golangci-lint run --fix --allow-parallel-runners`, then `golangci-lint run --allow-parallel-runners` until clean after corrections. Run at repo root without filenames so package context is available.
+2. Run `golangci-lint run --fix -j 8 --allow-parallel-runners`, then `golangci-lint run -j 8 --allow-parallel-runners` until clean after corrections. Run at repo root without filenames so package context is available. Keep `-j 8`: on a cold cache it trades ~15s of wall time for ~30% less CPU and ~1.5 GB less peak RSS on the shared box.
 3. Run tests for changed packages and affected behavior, including required collision or contention coverage.
 4. Build: `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`.
 5. After dependency changes, run `go mod tidy` and recheck affected code.


### PR DESCRIPTION
## What

Two small cleanups to the lint setup, found while investigating why `golangci-lint` is slow and memory-hungry.

**1. The exclusion list was almost entirely dead.**

| Entry | Status |
|---|---|
| `proto/generated-go` | Directory does not exist; `proto/` has **0** Go files. Generated Go moved to `backend/generated-go/`. |
| `third_party`, `builtin`, `examples` | No such directories anywhere in the repo. |
| `frontend` | Exists, but holds **0** Go files. |

Repointed the first at the real generated directory and deleted the other four, in both the `linters` and `formatters` blocks.

**2. `-j 8` on the local command in `AGENTS.md`**, matching what CI already passes.

## Reported output is unchanged

Generated code was already exempt via `exclusions.generated: lax` reading the `DO NOT EDIT.` headers, so this does not newly silence anything. The path entry goes from a no-op to belt-and-braces.

Verified by setting `exclusions.generated: disable` and running with vs. without the path entry:

| Config | Issues in `backend/generated-go` |
|---|---|
| path entry present | **0** |
| path entry removed | **4** (3 gocritic, 1 misspell) |

`golangci-lint run` reports `0 issues.` before and after.

## What `-j 8` buys

Measured on the runner box (20 vCPU / 31 GB), golangci cache cleared before each run, all four runs started at load < 1.3:

| | wall | CPU | peak RSS |
|---|---|---|---|
| default (`-j 20`) | 53.7s / 50.8s | 740s / 723s | 12.87 / 12.62 GB |
| `-j 8` | 67.4s / 67.8s | 498s / 498s | 10.83 / 11.40 GB |

~15s more wall for ~30% less CPU and ~1.6 GB less peak RSS. Warm runs are ~2.7s and ~0.2 GB either way, so the flag only matters after a cache wipe.

## This is not a speed-up

Worth stating plainly, since the config now carries a comment saying so. `exclusions.paths` filters **reported issues**; it does not reduce work. Excluded paths are still loaded, type-checked and analyzed, and all issue processing is 132 ms — 0.08% of a cold run.

Two things I measured and discarded:

- Removing `backend/generated-go` from the analysis **targets** (144K LOC, 25% of the Go code, a stronger move than a path exclusion): CPU 738s → 721s, i.e. noise. Those packages stay in the graph as dependencies of `backend/api/v1` and friends, so their IR is built regardless.
- Restricting `go list` to the three real directories so it stops walking `frontend/node_modules` (66,556 files, 799 MB): 0.97s → 0.95s. Noise.

The lever that actually moves the number is cache persistence — a cold run is 2:47 / 2530 CPU-s / 12.9 GB against 2.9s / 20 CPU-s / 0.19 GB warm. That lives in the devbox startup script, not this repo, and is not part of this PR.

## Note

The ~100 historical plan documents under `docs/plans/` and `docs/superpowers/plans/` still show the flagless command. They are records of past work, not instructions, so they were left alone; `AGENTS.md` is the instruction source of truth.

## Test plan

- [x] `golangci-lint config verify` clean
- [x] `golangci-lint run -j 8 --allow-parallel-runners` → `0 issues.`
- [x] Both newly documented commands run verbatim; `--fix` touches no files
- [x] A/B test above proves the repointed path actually matches
- [x] Pre-PR checklist: sections 3–6 and 8 skip (no `backend/store`, `migrator`, `tests`, proto or code changes); section 2 does not apply — lint config is not user-facing configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)