### PR TITLE
docs(design): show what an MCP access policy mode allows

### DIFF
--- a/docs/design/mcp-capability-ladder.md
+++ b/docs/design/mcp-capability-ladder.md
@@ -1,6 +1,6 @@
 # MCP access policy — show what a mode allows
 
-Status: proposal · 2026-09-09
+Status: proposal · 2026-09-10
 
 The MCP settings page offers three modes (Disabled, Read-only, Read-write) and describes each in
 one sentence. Since [#21324](https://github.com/bytebase/bytebase/pull/21324) removed the per-mode
@@ -8,10 +8,12 @@ method drawer, nothing on the page says what a mode actually serves, and an admi
 Read-only and Read-write has nothing to compare beyond two sentences. The rule this doc lands on:
 **show capabilities, not methods or permissions — one ordered list of eight capability rows in
 which each mode is a prefix, collapsed by default inside the existing Access policy section, and
-following the picked mode while editing.** The product change is frontend-only. One backend lint
-binds the row wording to the method classification, so the list cannot drift from what the gate
-serves. A custom access policy is out of scope, but the list is shaped so that it becomes that
-editor later without a redesign.
+following the picked mode while editing.** The page also gets shorter: the mode cards become a
+slider with the selected mode's "Best for" under it, the disclosure line is the mode's description,
+and row details sit behind one toggle. The product change is frontend-only. One backend lint binds
+the row wording to the method classification, so the list cannot drift from what the gate serves. A
+custom access policy is out of scope, but the list is shaped so that it becomes that editor later
+without a redesign.
 
 ## Problem
 
@@ -34,6 +36,10 @@ ceiling gate (`backend/api/v1/mcp_gate.go`) removes *methods* by class before th
 runs, and under Read-only the SQL clamp removes *statements*. So the page has to say what an agent
 can do, in the admin's words, and say it in a form that stays true after the next release.
 
+A second problem surfaced once the list existed: the edit state carried about 375 words, most of
+them duplicated. The three mode cards described what the list already showed, and every row's
+detail line was visible whether or not anyone wanted it.
+
 ## Principle
 
 > **A capability is a verb phrase an admin recognizes, backed by an exact set of served methods in
@@ -47,6 +53,9 @@ What follows from it:
 - Rows a mode does not serve stay visible and muted, so comparing modes never needs a second
   surface.
 - What no mode serves is one line under the list, never a row.
+- Nothing on the section is said twice. The mode name appears in the chip or the slider; the
+  description in the disclosure line; the audience in the "Best for" line; the detail behind one
+  toggle.
 
 ## The rows
 
@@ -102,11 +111,12 @@ One verb for the whole write tier was tried and rejected:
   exist to protect.
 - **Manage** for all five: hides the hazard on exports and on SQL.
 
-Per row: *Propose* over Create (Create fits the method names but hides that a human still
-approves); *Export* over Read or Download (Read hides the egress hazard, which is why Export is
-WRITE-class in the first place); *Manage* over Update or Maintain (Update reads as a data change,
-Maintain is vague). Rollouts and DML/DDL both take *Run* and stay two rows, because a custom policy
-will want "run approved rollouts, but no ad-hoc SQL" — the workflow the product exists for.
+Per row: *Propose* over Create (Create fits the method names but hides that the project's approval
+policy may still require a human); *Export* over Read or Download (Read hides the egress hazard,
+which is why Export is WRITE-class in the first place); *Manage* over Update or Maintain (Update
+reads as a data change, Maintain is vague). Rollouts and DML/DDL both take *Run* and stay two rows,
+because a custom policy will want "run approved rollouts, but no ad-hoc SQL" — the workflow the
+product exists for.
 
 The tier is named once, by the dividers, so no row repeats it in its title.
 
@@ -114,41 +124,51 @@ The tier is named once, by the dividers, so no row repeats it in its title.
 
 **D1 — Placement: a disclosure inside the Access policy section, collapsed by default.**
 Not a drawer (a second surface, one mode at a time) and not a separate section (it belongs to the
-policy it describes). One trigger line, "What Read-only allows · Read schemas, data and the change
-workflow; nothing is written or exported", expands inline into the list. In view state it sits
-under the mode sentence; in edit state it sits under the three mode cards, above the masking
-toggle, so the cause and its effect are adjacent. The open state persists per browser and carries
-across the view-to-edit transition within a page visit.
+policy it describes). Collapsed, the trigger line *is* the mode's description: "▸ Read everything,
+and propose, run, export and manage". It never repeats the mode name, which the chip (view) or the
+slider (edit) already shows. Expanded, it becomes the list heading "Read-write allows", with a
+"Show details" control on the right. In view state it sits under the chip line; in edit state it
+sits under the slider and its "Best for" line, above the masking toggle, so the cause and its
+effect are adjacent. The open state persists per browser and carries across the view-to-edit
+transition within a page visit.
 
-**D2 — Content: rows and sub-items only.** No method names, no permission names, no counts, no
-link to a method list. The floor is kept as one short line because it is what a security-minded
-admin reads first, and it is what keeps the list honest about the 121 methods no mode reaches.
-There is no constants line under the list; the facts it would carry (capped by the user's own
-permissions, refusals audited) move into the section description.
+**D2 — Content: rows first, sub-items behind one toggle.** Expanded, each row shows its title and
+its tier tag, nothing else. "Show details" reveals the sub-item line for every row at once, so
+there is one second-level control rather than eight; per-row expanders were rejected as fiddly. No
+method names, no permission names, no counts, no link to a method list. The floor is kept as one
+short line because it is what a security-minded admin reads first, and it is what keeps the list
+honest about the 121 methods no mode reaches. There is no constants line under the list; the facts
+it would carry (capped by the user's own permissions, refusals audited) move into the section
+description.
 
-**D3 — The mode chip is the subject; the "In force" line goes.** The three-stripe icon and the
-words "In force" are removed. View state reads: the mode chip (success for Read-only, warning for
-Read-write, destructive for Disabled), the "Masking exemptions ignored" chip when set, Edit policy
-on the right; then the mode's one sentence; then the disclosure. "Active" was considered and
-rejected as the label: "Active · Disabled" contradicts itself, and a chip under a section titled
-Access policy needs no label. The chip carries `aria-label="Current policy: Read-only"`. The icon
-also leaves the mode cards, so color appears in exactly two places: the chip in view, the selected
-border in edit.
+**D3 — The mode chip is the subject; the "In force" line and the mode sentence go.** The
+three-stripe icon and the words "In force" are removed. View state reads: the mode chip (success
+for Read-only, warning for Read-write, destructive for Disabled), the "Masking exemptions ignored"
+chip when set, Edit policy on the right; then the disclosure line, which carries the description.
+The separate sentence under the chip is retired for Read-only and Read-write, since the disclosure
+line says the same thing; Disabled keeps its sentence, "No MCP session can connect to this
+workspace.", because it has no list. "Active" was considered and rejected as the label: "Active ·
+Disabled" contradicts itself, and a chip under a section titled Access policy needs no label. The
+chip carries `aria-label="Current policy: Read-only"`.
 
-**D4 — The two notes under the card move.** "A ceiling change applies to the next request…" shows
-only while editing, and it names the change when the form is dirty: "Changing Read-only to
-Read-write applies to the next request of every running session; work already admitted runs to
-completion." "MCP policy denials are recorded in the audit log" is a fact about the feature, not
-about the current state, so it joins the section description: "The most any MCP session may do in
-this workspace. Every session is also capped by the connecting user's own permissions, and every
-refusal is recorded in the audit log."
+**D4 — The two notes under the card move and shrink.** "A ceiling change applies to the next
+request…" shows only while editing, as "Applies to every running session's next request.", and
+names the change when the form is dirty: "Read-only → Read-write applies to every running
+session's next request." "MCP policy denials are recorded in the audit log" is a fact about the
+feature, not about the current state, so it joins the section description, which becomes: "The
+most any MCP session may do here. Sessions are also capped by each user's permissions, and refusals
+are audited."
 
-**D5 — Edit state renders the pick, and only the pick.** The disclosure under the cards shows
-exactly what the view would show after saving. No "adds N over Read-only", no added or removed
-marks, no comparison against the stored mode: the muted rows already show what a pick does not
-serve. The mode cards lose their visible radio; the card is the control, with the selected card
-carrying the accent border and a faint accent tint, hover lightening the border, and keyboard focus
-drawing the shared ring on the card. The radio group semantics stay.
+**D5 — Edit state: a slider, the selected mode's "Best for", and the pick's ladder.** The three
+mode cards and their descriptions are gone; they duplicated the ladder. The selector is the shared
+segmented control with three equal-width segments, Disabled · Read-only · Read-write, so the
+control reads as one setting rather than three labels of different sizes. Under it, one line: the
+"Best for" of the selected mode. "Best for" survives because it answers a different question from
+the ladder — who the mode is for — and it is now shown once instead of three times. Under that,
+the disclosure for the picked mode, rendering exactly what the view would show after saving. No
+"adds N over Read-only", no added or removed marks, no comparison against the stored mode: the muted
+rows already show what a pick does not serve. The edit state is about 100 words collapsed and 150
+expanded, down from about 215 and 375 in the first draft of this design.
 
 **D6 — Marks: ✓ or —, plus a tier tag on served rows only.** A served row shows ✓, a `success`
 "read" badge or a `warning` "write" badge after its title, and full-contrast text. An unserved row
@@ -156,16 +176,18 @@ shows —, muted text, and no badge. Under Read-only the write rows are unserved
 never appears there.
 
 **D7 — Disabled.** In view, the chip and the sentence "No MCP session can connect to this
-workspace" are the whole answer; no disclosure. In edit with Disabled picked, the disclosure slot
-holds a static line in the floor's soft error tone, "Disabled · nothing, no MCP session can
-connect", so red means "no capability" everywhere on the card. It is not a button.
+workspace." are the whole answer; no disclosure. In edit with Disabled picked, the slider sits on
+Disabled, the "Best for" line reads "keeping MCP off until you are ready to turn it on", and the
+disclosure slot holds a static line in the floor's soft error tone, "Nothing is allowed; no MCP
+session can connect.", so red means "no capability" everywhere on the card. It is not a button and
+does not repeat the mode name.
 
-**D8 — Copy that shrinks.** The Read-only card drops to two sentences plus its "Best for" line:
-"Sessions can explore schemas and run read-only queries. Every statement is checked before it
-runs." The classifier and driver-depth detail it carried moves to docs; the "refused whole" rule
-lives in row 2's sub-item. The masking toggle's two paragraphs become one sentence: "If enabled, a
-user's masking exemptions and access-grant unmasks do not apply in MCP sessions; masked data stays
-masked. The console is unaffected."
+**D8 — Copy that shrinks.** The masking toggle's two paragraphs become one sentence: "If enabled,
+masked data stays masked in MCP sessions even for users with exemptions or unmask grants. The
+console is unaffected." The engine caveat it carried moves to docs. The three "Best for" lines keep
+their current wording. The Read-only description sentence ("Sessions can explore schemas and run
+read-only queries…") is retired everywhere; its content lives in the Read-only summary and in row
+2's sub-item.
 
 **D9 — The Authentication Required alert on the MCP page is removed.** Its two sentences already
 exist on the page: "approve access in the browser" in the Connect a client description, and
@@ -190,11 +212,11 @@ shows no counts, so the frontend needs only the static tier of each row.
 
 | State | What the section shows |
 |---|---|
-| View · Read-only or Read-write | Chip line with Edit policy; the mode sentence; the disclosure, collapsed. Nothing below it. |
+| View · Read-only or Read-write | Chip line with Edit policy; the disclosure line as the description, collapsed. Nothing below it. |
 | View · Disabled | Chip line; "No MCP session can connect to this workspace." No disclosure. |
 | View · unreadable, unserved, read failed | The existing warning or error, unchanged. No disclosure. |
-| Edit · Read-only or Read-write picked | Three selectable cards; the disclosure for the picked mode, collapsed by default, rendering the post-save view; masking toggle; separator; footer sentence (naming the change when dirty), Cancel, Save (enabled only when dirty). |
-| Edit · Disabled picked | As above, with the disclosure slot holding the static soft-error line. |
+| Edit · Read-only or Read-write picked | Slider on the pick; the pick's "Best for" line; the disclosure for the pick, collapsed by default, rendering the post-save view, with "Show details" once expanded; masking toggle; separator; footer sentence (naming the change when dirty), Cancel, Save (enabled only when dirty). |
+| Edit · Disabled picked | Slider on Disabled; its "Best for" line; the static soft-error line in the disclosure slot. |
 | Consent page | Served row titles with ✓, the ✕ line under Read-only, then the existing constants and caution. |
 
 ## Copy
@@ -203,21 +225,23 @@ All strings, so the change and the locale files have one source. Keys under
 `settings.mcp.ladder.*` are new; the rest replace existing `settings.mcp.*` and
 `oauth2.consent.mcp.*` values.
 
-- Section description: "The most any MCP session may do in this workspace. Every session is also
-  capped by the connecting user's own permissions, and every refusal is recorded in the audit log."
-- Trigger: "What {mode} allows". Summaries — Read-only: "Read schemas, data and the change
-  workflow; nothing is written or exported". Read-write: "Read everything, and propose, run, export
-  and manage". Disabled (static): "Disabled · nothing, no MCP session can connect".
+- Section description: "The most any MCP session may do here. Sessions are also capped by each
+  user's permissions, and refusals are audited."
+- Disclosure line, collapsed — Read-only: "Read schemas, data and the change workflow; nothing is
+  written or exported". Read-write: "Read everything, and propose, run, export and manage".
+  Expanded heading: "{mode} allows". Details control: "Show details" / "Hide details".
+- Disabled — view sentence: "No MCP session can connect to this workspace." Edit static line:
+  "Nothing is allowed; no MCP session can connect."
+- "Best for" lines, unchanged: Disabled "keeping MCP off until you are ready to turn it on";
+  Read-only "querying and exploring data, including by people who do not write SQL"; Read-write
+  "making database changes through an AI agent, still capped by each user's own permissions".
 - Row titles and sub-items: the table above, verbatim.
 - Dividers: "Read-only stops here", "Read-write stops here".
 - Floor: "Never, in any mode: approve issues, administer the workspace, or handle credentials."
 - Tier badges: "read", "write".
-- Read-only card: "Sessions can explore schemas and run read-only queries. Every statement is
-  checked before it runs." Best-for line unchanged.
 - Masking toggle: the one sentence in D8.
-- Footer, clean: "Changes apply to the next request of every running session; work already
-  admitted runs to completion." Dirty: "Changing {from} to {to} applies to the next request of every
-  running session; work already admitted runs to completion."
+- Footer, clean: "Applies to every running session's next request." Dirty: "{from} → {to} applies
+  to every running session's next request."
 - Connect a client: the sentence in D9.
 - Consent: row titles; "No changes, rollouts or exports".
 
@@ -226,30 +250,37 @@ All strings, so the change and the locale files have one source. Keys under
 ### Frontend
 
 - New `MCPCapabilityLadder` beside `MCPAccessPolicySection.tsx`, props `mode`, `expanded`,
-  `onToggle`. It derives the served set from the mode by tier: READ_ONLY serves the read rows,
-  READ_WRITE both tiers, DISABLED none. No comparison logic.
+  `details`, `onToggle`, `onToggleDetails`. It derives the served set from the mode by tier:
+  READ_ONLY serves the read rows, READ_WRITE both tiers, DISABLED none. No comparison logic.
 - Disclosure behavior belongs in a shared primitive per the UX contract. There is no
   `Collapsible` in `frontend/src/components/ui/` today; add one wrapping Base UI's Collapsible
   (trigger with `aria-expanded`, panel region) rather than hand-rolling it in the feature.
+- The mode selector is the shared `SegmentedControl` at size `md`. It sizes each segment to its
+  label today; add an equal-width option to the primitive (equal grid columns, or a shared
+  minimum width per segment) rather than styling it in the feature. The `RadioGroup` cards and
+  their `radioClassName` go away.
 - The ladder is an unframed region: the trigger row and the rows are separated by
   `border-block-border` hairlines, with no outer frame, so the change adds no card inside the
   section's existing framed card. (Design mocks draw a light border around the ladder for
   legibility; the implementation does not.)
-- Marks use the shared `Badge` (`success` for read, `warning` for write). The floor line uses the
-  `error` semantic tokens at low opacity; no raw palette colors, no `dark:` variants.
-- `MCPAccessPolicySection.tsx`: remove the `Rows3` icon and the in-force string; render the chip as
-  the sentence subject with the aria-label; move the audit sentence to the section description;
-  show the tightening sentence only while editing and interpolate both modes when dirty; replace the
-  masking copy; pass `radioClassName="sr-only"` to `RadioGroupItem` and verify the item shows the
-  shared focus ring with the radio hidden.
+- Marks use the shared `Badge` (`success` for read, `warning` for write). The floor line and the
+  Disabled static line use the `error` semantic tokens at low opacity; no raw palette colors, no
+  `dark:` variants.
+- `MCPAccessPolicySection.tsx`: remove the `Rows3` icon, the in-force string, the mode cards and
+  the mode sentence; render the chip with its aria-label; add the slider and the "Best for" line;
+  move the audit sentence to the section description; show the footer sentence only while editing
+  and interpolate both modes when dirty; replace the masking copy.
 - `MCPPage.tsx`: remove the Authentication Required alert; extend the Connect a client description.
 - `MCPConsentCeiling.tsx`: replace the read, write and workflow lines with the row titles from the
   same table.
 - Locale: keys under `settings.mcp.ladder.*` in all five locale files;
-  `frontend/scripts/check-react-i18n.mjs` guards them.
+  `frontend/scripts/check-react-i18n.mjs` guards them. The retired mode-description keys are
+  removed, not left empty.
 - Tests: the served set per mode; the disclosure collapsed by default, opens, persists, and follows
-  the pick; Disabled renders the static line in edit and nothing in view; the consent page renders
-  the row titles; one e2e case that edits Read-only to Read-write, saves, and sees the chip change.
+  the pick; the details toggle reveals sub-items on every row and persists with the open state; the
+  "Best for" line follows the slider; Disabled renders the static line in edit and the sentence in
+  view; the consent page renders the row titles; one e2e case that edits Read-only to Read-write,
+  saves, and sees the chip change.
 - Run `node frontend/scripts/check-ui-guideline.mjs`; the change must not add to the legacy
   baseline.
 
@@ -265,8 +296,8 @@ All strings, so the change and the locale files have one source. Keys under
 
 ## Out of scope
 
-- A custom access policy. When it comes, the rows become checkboxes, the three cards become preset
-  buttons that select a prefix, and a policy matching no prefix shows a Custom chip; the backend
+- A custom access policy. When it comes, the rows become checkboxes, the slider becomes a preset
+  picker that selects a prefix, and a policy matching no prefix shows a Custom chip; the backend
   row table is what the gate would read. The ladder needs no redesign.
 - A docs page listing the methods per row, generated from the inventory. Worth doing; not linked
   from the card until it exists.
@@ -276,8 +307,8 @@ All strings, so the change and the locale files have one source. Keys under
 
 ## Open questions
 
-- The Access policy section is a framed card containing the mode cards, which predates the "no
-  cards inside cards" rule. This change does not add nesting, but unframing the section is a
+- The Access policy section is a framed card, which predates the "no cards inside cards" rule.
+  This change adds no nesting and removes the nested mode cards, so unframing the section is a
   natural follow-up.
 - Whether the consent page should also show the sub-items. The proposal shows titles only, to keep
   the approval screen short.

--- a/docs/design/mcp-capability-ladder.md
+++ b/docs/design/mcp-capability-ladder.md
@@ -1,0 +1,271 @@
+# MCP access policy — show what a mode allows
+
+Status: proposal · 2026-09-09
+
+The MCP settings page offers three modes (Disabled, Read-only, Read-write) and describes each in
+one sentence. Since [#21324](https://github.com/bytebase/bytebase/pull/21324) removed the per-mode
+method drawer, nothing on the page says what a mode actually serves, and an admin choosing between
+Read-only and Read-write has nothing to compare beyond two sentences. The rule this doc lands on:
+**show capabilities, not methods or permissions — one ordered list of eight capability rows in
+which each mode is a prefix, collapsed by default inside the existing Access policy section, and
+following the picked mode while editing.** The product change is frontend-only. One backend lint
+binds the row wording to the method classification, so the list cannot drift from what the gate
+serves. A custom access policy is out of scope, but the list is shaped so that it becomes that
+editor later without a redesign.
+
+## Problem
+
+The page today (`frontend/src/routes/workspace/mcp/MCPAccessPolicySection.tsx`) shows, in view
+state, an "In force" line with the mode chip, the mode's description, and two notes; in edit
+state, three mode cards, the masking toggle, and a footer. The consent page
+(`frontend/src/routes/auth/MCPConsentCeiling.tsx`) renders three prose lines for the same policy.
+None of these says what an agent can do.
+
+The drawer that used to answer this listed every served method grouped by service, with the
+permission each declares, plus per-engine read-only depth and masking. It went with the
+`GetMCPInfo` fields it read, because a large API whose only reader was one drawer was not worth
+keeping, and because a list served by the backend and rendered by the frontend drifts. It also
+answered the wrong question. An admin does not think in `DatabaseService/GetDatabaseSDLSchema`,
+and comparing two modes meant opening two drawers.
+
+The gap, as raised in review: some admins need to understand what each mode really allows. The
+word "permissions" is itself the trap here. A mode never grants or removes a permission; the
+ceiling gate (`backend/api/v1/mcp_gate.go`) removes *methods* by class before the permission check
+runs, and under Read-only the SQL clamp removes *statements*. So the page has to say what an agent
+can do, in the admin's words, and say it in a form that stays true after the next release.
+
+## Principle
+
+> **A capability is a verb phrase an admin recognizes, backed by an exact set of served methods in
+> code. The three modes are nested, so one ordered list with two dividers shows all three at once,
+> and the mode in force — or the mode being picked — is a highlighted prefix of that list.**
+
+What follows from it:
+
+- The unit shown is a capability row, never a method, a permission, or a count.
+- The list is the same in view and in edit. Editing changes which prefix is served, nothing else.
+- Rows a mode does not serve stay visible and muted, so comparing modes never needs a second
+  surface.
+- What no mode serves is one line under the list, never a row.
+
+## The rows
+
+Eight rows: three read, five write. Each has a title, a one-line list of sub-items in plain words,
+and — in code only — the set of served methods it stands for. The right column here is the code
+mapping; it never appears in the product.
+
+| Tier | Row | Sub-items shown | Backed by (code only) |
+|---|---|---|---|
+| read | Read schemas and metadata | Schemas · Databases and instances · Projects and database groups · Catalogs, changelogs and revisions · SQL review configs · Your own session and workspace facts | 31 READ methods: `DatabaseService` reads, projects, instances, database groups, catalogs, changelogs, revisions, review configs, session facts |
+| read | Read data by running queries | Run read-only queries; a request is refused whole if any statement is not a read · Query history · Saved queries and sheets | 9 READ methods: `SQLService/Query`, query history (4), saved-query reads (3), `GetSheet` |
+| read | Read the change workflow | Issues and comments · Plans and plan checks · Rollouts, task runs and logs · Releases · Rollback previews | 16 READ methods: issue, plan, rollout and release reads |
+| — | *Read-only stops here* | | 56 methods |
+| write | Propose changes | Create and edit sheets, plans and issues · Run plan checks and reviews · Create releases and revisions · Generate schema diffs. A human still approves; an agent never approves its own change | 22 WRITE methods: sheet, plan, issue, release and revision writes, `RequestIssue`, `RunReview`, `DiffSchema`, `DiffMetadata` |
+| write | Run rollouts and tasks | Create a rollout · Run, skip or cancel tasks of an approved change | 4 WRITE methods: `CreateRollout`, `BatchRunTasks`, `BatchSkipTasks`, `BatchCancelTaskRuns` |
+| write | Run DML and DDL statements | INSERT, UPDATE, DELETE, CREATE, ALTER, DROP through queries, where the engine checks each statement and the user may run it | Not a method: the statement clamp in `mcp_sql_clamp.go`, which Read-write lifts |
+| write | Export query results | Download results as a file. Data leaves Bytebase | 1 WRITE method: `SQLService/Export` |
+| write | Manage database housekeeping | Sync instances and databases · Database settings and labels · Database groups · Saved queries | 14 WRITE methods: sync, `UpdateDatabase`, database groups, saved-query writes |
+| — | *Read-write stops here* | | 97 methods |
+| floor | Never, in any mode: approve issues, administer the workspace, or handle credentials. | | 121 methods: 35 FORBIDDEN, 86 EXCLUDED |
+
+Two choices in the wording are deliberate. Row 2 says *Read data by running queries* rather than
+"Run queries" so the verb stays Read and the sub-item carries the rule that keeps it true under
+Read-only. Row 6 is not a method at all: it names the statement clamp being lifted, because that is
+a real difference between the modes that no method name shows, and a future custom policy will want
+it as its own switch.
+
+### The verb rule
+
+The verb names the row's effect on the customer's databases. *Read*: none. *Propose*: none until a
+human approves. *Run*: direct. *Export*: data leaves the product. *Manage*: configuration only, no
+data path. Within a tier the verb repeats; it changes only where the effect changes.
+
+One verb for the whole write tier was tried and rejected:
+
+- **Write** for all five: "Write query results" (export writes nothing to a database), "Write
+  change proposals" (nothing reaches a database until approval), "Write rollouts" (not English),
+  "Write database housekeeping" (reads as a data change).
+- **Change** for all five: fails for exports and rollouts, and makes "Change proposals" and
+  "Change data with SQL" read as the same thing — the distinction the FORBIDDEN approval methods
+  exist to protect.
+- **Manage** for all five: hides the hazard on exports and on SQL.
+
+Per row: *Propose* over Create (Create fits the method names but hides that a human still
+approves); *Export* over Read or Download (Read hides the egress hazard, which is why Export is
+WRITE-class in the first place); *Manage* over Update or Maintain (Update reads as a data change,
+Maintain is vague). Rollouts and DML/DDL both take *Run* and stay two rows, because a custom policy
+will want "run approved rollouts, but no ad-hoc SQL" — the workflow the product exists for.
+
+The tier is named once, by the dividers, so no row repeats it in its title.
+
+## Decisions
+
+**D1 — Placement: a disclosure inside the Access policy section, collapsed by default.**
+Not a drawer (a second surface, one mode at a time) and not a separate section (it belongs to the
+policy it describes). One trigger line, "What Read-only allows · Read schemas, data and the change
+workflow; nothing is written or exported", expands inline into the list. In view state it sits
+under the mode sentence; in edit state it sits under the three mode cards, above the masking
+toggle, so the cause and its effect are adjacent. The open state persists per browser and carries
+across the view-to-edit transition within a page visit.
+
+**D2 — Content: rows and sub-items only.** No method names, no permission names, no counts, no
+link to a method list. The floor is kept as one short line because it is what a security-minded
+admin reads first, and it is what keeps the list honest about the 121 methods no mode reaches.
+There is no constants line under the list; the facts it would carry (capped by the user's own
+permissions, refusals audited) move into the section description.
+
+**D3 — The mode chip is the subject; the "In force" line goes.** The three-stripe icon and the
+words "In force" are removed. View state reads: the mode chip (success for Read-only, warning for
+Read-write, destructive for Disabled), the "Masking exemptions ignored" chip when set, Edit policy
+on the right; then the mode's one sentence; then the disclosure. "Active" was considered and
+rejected as the label: "Active · Disabled" contradicts itself, and a chip under a section titled
+Access policy needs no label. The chip carries `aria-label="Current policy: Read-only"`. The icon
+also leaves the mode cards, so color appears in exactly two places: the chip in view, the selected
+border in edit.
+
+**D4 — The two notes under the card move.** "A ceiling change applies to the next request…" shows
+only while editing, and it names the change when the form is dirty: "Changing Read-only to
+Read-write applies to the next request of every running session; work already admitted runs to
+completion." "MCP policy denials are recorded in the audit log" is a fact about the feature, not
+about the current state, so it joins the section description: "The most any MCP session may do in
+this workspace. Every session is also capped by the connecting user's own permissions, and every
+refusal is recorded in the audit log."
+
+**D5 — Edit state renders the pick, and only the pick.** The disclosure under the cards shows
+exactly what the view would show after saving. No "adds N over Read-only", no added or removed
+marks, no comparison against the stored mode: the muted rows already show what a pick does not
+serve. The mode cards lose their visible radio; the card is the control, with the selected card
+carrying the accent border and a faint accent tint, hover lightening the border, and keyboard focus
+drawing the shared ring on the card. The radio group semantics stay.
+
+**D6 — Marks: ✓ or —, plus a tier tag on served rows only.** A served row shows ✓, a `success`
+"read" badge or a `warning` "write" badge after its title, and full-contrast text. An unserved row
+shows —, muted text, and no badge. Under Read-only the write rows are unserved, so a "write" badge
+never appears there.
+
+**D7 — Disabled.** In view, the chip and the sentence "No MCP session can connect to this
+workspace" are the whole answer; no disclosure. In edit with Disabled picked, the disclosure slot
+holds a static line in the floor's soft error tone, "Disabled · nothing, no MCP session can
+connect", so red means "no capability" everywhere on the card. It is not a button.
+
+**D8 — Copy that shrinks.** The Read-only card drops to two sentences plus its "Best for" line:
+"Sessions can explore schemas and run read-only queries. Every statement is checked before it
+runs." The classifier and driver-depth detail it carried moves to docs; the "refused whole" rule
+lives in row 2's sub-item. The masking toggle's two paragraphs become one sentence: "If enabled, a
+user's masking exemptions and access-grant unmasks do not apply in MCP sessions; masked data stays
+masked. The console is unaffected."
+
+**D9 — The Authentication Required alert on the MCP page is removed.** Its two sentences already
+exist on the page: "approve access in the browser" in the Connect a client description, and
+"appropriate permissions" in the section description. Connect a client gains the one clause that
+was useful: "Add Bytebase to your AI client and start asking. On first connection you sign in and
+approve access in the browser."
+
+**D10 — The consent page uses the row titles.** "This session may" lists the served rows with ✓,
+one ✕ line for the unserved tier under Read-only ("No changes, rollouts or exports"), then the
+existing capped, masking and audit lines. Read-write keeps its caution. One wording table serves
+both surfaces.
+
+**D11 — A backend lint binds the wording to the classification.** A table in
+`backend/api/v1/mcp_gate.go` assigns every served method to exactly one row, and a lint in
+`mcp_gate_test.go` holds it: every READ or WRITE method is in a row, no FORBIDDEN or EXCLUDED
+method is, the read rows are exactly the READ set and the write rows exactly the WRITE set. A
+class change that moves a method across tiers then fails CI until the table — and therefore the row
+wording — is reviewed. No proto change, no new API, no generated file for the frontend: the product
+shows no counts, so the frontend needs only the static tier of each row.
+
+## States
+
+| State | What the section shows |
+|---|---|
+| View · Read-only or Read-write | Chip line with Edit policy; the mode sentence; the disclosure, collapsed. Nothing below it. |
+| View · Disabled | Chip line; "No MCP session can connect to this workspace." No disclosure. |
+| View · unreadable, unserved, read failed | The existing warning or error, unchanged. No disclosure. |
+| Edit · Read-only or Read-write picked | Three selectable cards; the disclosure for the picked mode, collapsed by default, rendering the post-save view; masking toggle; separator; footer sentence (naming the change when dirty), Cancel, Save (enabled only when dirty). |
+| Edit · Disabled picked | As above, with the disclosure slot holding the static soft-error line. |
+| Consent page | Served row titles with ✓, the ✕ line under Read-only, then the existing constants and caution. |
+
+## Copy
+
+All strings, so the change and the locale files have one source. Keys under
+`settings.mcp.ladder.*` are new; the rest replace existing `settings.mcp.*` and
+`oauth2.consent.mcp.*` values.
+
+- Section description: "The most any MCP session may do in this workspace. Every session is also
+  capped by the connecting user's own permissions, and every refusal is recorded in the audit log."
+- Trigger: "What {mode} allows". Summaries — Read-only: "Read schemas, data and the change
+  workflow; nothing is written or exported". Read-write: "Read everything, and propose, run, export
+  and manage". Disabled (static): "Disabled · nothing, no MCP session can connect".
+- Row titles and sub-items: the table above, verbatim.
+- Dividers: "Read-only stops here", "Read-write stops here".
+- Floor: "Never, in any mode: approve issues, administer the workspace, or handle credentials."
+- Tier badges: "read", "write".
+- Read-only card: "Sessions can explore schemas and run read-only queries. Every statement is
+  checked before it runs." Best-for line unchanged.
+- Masking toggle: the one sentence in D8.
+- Footer, clean: "Changes apply to the next request of every running session; work already
+  admitted runs to completion." Dirty: "Changing {from} to {to} applies to the next request of every
+  running session; work already admitted runs to completion."
+- Connect a client: the sentence in D9.
+- Consent: row titles; "No changes, rollouts or exports".
+
+## Implementation
+
+### Frontend
+
+- New `MCPCapabilityLadder` beside `MCPAccessPolicySection.tsx`, props `mode`, `expanded`,
+  `onToggle`. It derives the served set from the mode by tier: READ_ONLY serves the read rows,
+  READ_WRITE both tiers, DISABLED none. No comparison logic.
+- Disclosure behavior belongs in a shared primitive per the UX contract. There is no
+  `Collapsible` in `frontend/src/components/ui/` today; add one wrapping Base UI's Collapsible
+  (trigger with `aria-expanded`, panel region) rather than hand-rolling it in the feature.
+- The ladder is an unframed region: the trigger row and the rows are separated by
+  `border-block-border` hairlines, with no outer frame, so the change adds no card inside the
+  section's existing framed card. (Design mocks draw a light border around the ladder for
+  legibility; the implementation does not.)
+- Marks use the shared `Badge` (`success` for read, `warning` for write). The floor line uses the
+  `error` semantic tokens at low opacity; no raw palette colors, no `dark:` variants.
+- `MCPAccessPolicySection.tsx`: remove the `Rows3` icon and the in-force string; render the chip as
+  the sentence subject with the aria-label; move the audit sentence to the section description;
+  show the tightening sentence only while editing and interpolate both modes when dirty; replace the
+  masking copy; pass `radioClassName="sr-only"` to `RadioGroupItem` and verify the item shows the
+  shared focus ring with the radio hidden.
+- `MCPPage.tsx`: remove the Authentication Required alert; extend the Connect a client description.
+- `MCPConsentCeiling.tsx`: replace the read, write and workflow lines with the row titles from the
+  same table.
+- Locale: keys under `settings.mcp.ladder.*` in all five locale files;
+  `frontend/scripts/check-react-i18n.mjs` guards them.
+- Tests: the served set per mode; the disclosure collapsed by default, opens, persists, and follows
+  the pick; Disabled renders the static line in edit and nothing in view; the consent page renders
+  the row titles; one e2e case that edits Read-only to Read-write, saves, and sees the chip change.
+- Run `node frontend/scripts/check-ui-guideline.mjs`; the change must not add to the legacy
+  baseline.
+
+### Backend
+
+- `mcpCapabilityRows` in `backend/api/v1/mcp_gate.go`: a map from row id to procedure names, next
+  to `mcpRequestShapeRefusals`, which it resembles in shape and intent.
+- Lint clauses in `mcp_gate_test.go`, each with a RED test that breaks one input: every served
+  method in exactly one row; no refused method in any row; read rows equal the READ set; write rows
+  equal the WRITE set.
+- `TestMCPClassificationInventory` gains a Row column in `testdata/mcp_method_classification.md`,
+  so a class or row change shows up as a reviewable diff.
+
+## Out of scope
+
+- A custom access policy. When it comes, the rows become checkboxes, the three cards become preset
+  buttons that select a prefix, and a policy matching no prefix shows a Custom chip; the backend
+  row table is what the gate would read. The ladder needs no redesign.
+- A docs page listing the methods per row, generated from the inventory. Worth doing; not linked
+  from the card until it exists.
+- Per-engine read-only depth and masking coverage. The removed drawer showed both; they belong in
+  docs, not on the policy card.
+- The ceiling gate itself, the classification, and the consent flow's mechanics.
+
+## Open questions
+
+- The Access policy section is a framed card containing the mode cards, which predates the "no
+  cards inside cards" rule. This change does not add nesting, but unframing the section is a
+  natural follow-up.
+- Whether the consent page should also show the sub-items. The proposal shows titles only, to keep
+  the approval screen short.

--- a/docs/design/mcp-capability-ladder.md
+++ b/docs/design/mcp-capability-ladder.md
@@ -182,10 +182,14 @@ disclosure slot holds a static line in the floor's soft error tone, "Nothing is 
 session can connect.", so red means "no capability" everywhere on the card. It is not a button and
 does not repeat the mode name.
 
-**D8 — Copy that shrinks.** The masking toggle's two paragraphs become one sentence: "If enabled,
-masked data stays masked in MCP sessions even for users with exemptions or unmask grants. The
-console is unaffected." The engine caveat it carried moves to docs. The three "Best for" lines keep
-their current wording. The Read-only description sentence ("Sessions can explore schemas and run
+**D8 — Copy that shrinks, but keeps the coverage limit.** The masking toggle's two paragraphs
+become: "If enabled, masked data stays masked in MCP sessions even for users with exemptions or
+unmask grants. Coverage depends on the engine: where Bytebase does not mask, this changes nothing.
+The console is unaffected." The middle sentence stays in the product on purpose. Masking runs only
+on the engines `common.EngineSupportMasking` lists; on the others the query masker falls back to a
+no-op, so on Snowflake or ClickHouse the toggle keeps nothing masked, and the setting's own proto
+comment says it "is not a confidentiality boundary". A toggle that promised more would mislead the
+admin it exists to protect. The three "Best for" lines keep their current wording. The Read-only description sentence ("Sessions can explore schemas and run
 read-only queries…") is retired everywhere; its content lives in the Read-only summary and in row
 2's sub-item.
 
@@ -239,7 +243,7 @@ All strings, so the change and the locale files have one source. Keys under
 - Dividers: "Read-only stops here", "Read-write stops here".
 - Floor: "Never, in any mode: approve issues, administer the workspace, or handle credentials."
 - Tier badges: "read", "write".
-- Masking toggle: the one sentence in D8.
+- Masking toggle: the three sentences in D8, including the engine-coverage limit.
 - Footer, clean: "Applies to every running session's next request." Dirty: "{from} → {to} applies
   to every running session's next request."
 - Connect a client: the sentence in D9.

--- a/docs/design/mcp-capability-ladder.md
+++ b/docs/design/mcp-capability-ladder.md
@@ -60,8 +60,8 @@ mapping; it never appears in the product.
 | read | Read data by running queries | Run read-only queries; a request is refused whole if any statement is not a read · Query history · Saved queries and sheets | 9 READ methods: `SQLService/Query`, query history (4), saved-query reads (3), `GetSheet` |
 | read | Read the change workflow | Issues and comments · Plans and plan checks · Rollouts, task runs and logs · Releases · Rollback previews | 16 READ methods: issue, plan, rollout and release reads |
 | — | *Read-only stops here* | | 56 methods |
-| write | Propose changes | Create and edit sheets, plans and issues · Run plan checks and reviews · Create releases and revisions · Generate schema diffs. A human still approves; an agent never approves its own change | 22 WRITE methods: sheet, plan, issue, release and revision writes, `RequestIssue`, `RunReview`, `DiffSchema`, `DiffMetadata` |
-| write | Run rollouts and tasks | Create a rollout · Run, skip or cancel tasks of an approved change | 4 WRITE methods: `CreateRollout`, `BatchRunTasks`, `BatchSkipTasks`, `BatchCancelTaskRuns` |
+| write | Propose changes | Create and edit sheets, plans and issues · Run plan checks and reviews · Create, edit and delete releases and revisions · Generate schema diffs. An agent never approves its own change; the project's approval policy decides whether a human must | 22 WRITE methods: sheet, plan, issue, release and revision writes, `RequestIssue`, `RunReview`, `DiffSchema`, `DiffMetadata` |
+| write | Run rollouts and tasks | Create a rollout · Run, skip or cancel its tasks, under the project's approval policy | 4 WRITE methods: `CreateRollout`, `BatchRunTasks`, `BatchSkipTasks`, `BatchCancelTaskRuns` |
 | write | Run DML and DDL statements | INSERT, UPDATE, DELETE, CREATE, ALTER, DROP through queries, where the engine checks each statement and the user may run it | Not a method: the statement clamp in `mcp_sql_clamp.go`, which Read-write lifts |
 | write | Export query results | Download results as a file. Data leaves Bytebase | 1 WRITE method: `SQLService/Export` |
 | write | Manage database housekeeping | Sync instances and databases · Database settings and labels · Database groups · Saved queries | 14 WRITE methods: sync, `UpdateDatabase`, database groups, saved-query writes |
@@ -73,6 +73,18 @@ Two choices in the wording are deliberate. Row 2 says *Read data by running quer
 Read-only. Row 6 is not a method at all: it names the statement clamp being lifted, because that is
 a real difference between the modes that no method name shows, and a future custom policy will want
 it as its own switch.
+
+Approval is stated as the project's policy, never as a promise. The backend requires an approved
+issue before a rollout only when the project has `require_issue_approval` on and an issue is linked
+(`backend/api/v1/rollout_service.go`); the MCP-origin guard there refuses an issueless rollout only
+under that same flag, and an issue whose approval finding produced no template counts as approved
+with no human acting. The console turns the flag on for new projects; the API default is off. A row
+that said "of an approved change" would therefore promise more than the gate enforces, and the
+wording an admin reads while choosing Read-write is the wrong place to be generous. What holds
+unconditionally is that an agent never approves its own change, because the three approval methods
+are FORBIDDEN, and that is the half the rows state. Whether MCP-originated rollouts should require
+approval regardless of the project flag is a product question tracked separately (BOT-71), not one
+this doc decides.
 
 ### The verb rule
 

--- a/docs/design/mcp-capability-ladder.md
+++ b/docs/design/mcp-capability-ladder.md
@@ -8,12 +8,12 @@ method drawer, nothing on the page says what a mode actually serves, and an admi
 Read-only and Read-write has nothing to compare beyond two sentences. The rule this doc lands on:
 **show capabilities, not methods or permissions — one ordered list of eight capability rows in
 which each mode is a prefix, collapsed by default inside the existing Access policy section, and
-following the picked mode while editing.** The page also gets shorter: the mode cards become a
-slider with the selected mode's "Best for" under it, the disclosure line is the mode's description,
-and row details sit behind one toggle. The product change is frontend-only. One backend lint binds
-the row wording to the method classification, so the list cannot drift from what the gate serves. A
-custom access policy is out of scope, but the list is shaped so that it becomes that editor later
-without a redesign.
+following the picked mode while editing.** The page also gets shorter: the mode cards shrink to an
+icon, a label and a three-word caption, with the selected mode's "Best for" under them; the
+disclosure line is the mode's description, and row details sit behind one toggle. The product
+change is frontend-only. One backend lint binds the row wording to the method classification, so
+the list cannot drift from what the gate serves. A custom access policy is out of scope, but the
+list is shaped so that it becomes that editor later without a redesign.
 
 ## Problem
 
@@ -53,7 +53,7 @@ What follows from it:
 - Rows a mode does not serve stay visible and muted, so comparing modes never needs a second
   surface.
 - What no mode serves is one line under the list, never a row.
-- Nothing on the section is said twice. The mode name appears in the chip or the slider; the
+- Nothing on the section is said twice. The mode name appears in the chip or the selector; the
   description in the disclosure line; the audience in the "Best for" line; the detail behind one
   toggle.
 
@@ -141,9 +141,10 @@ and the change workflow; propose, run, export and manage". The read half is the 
 both modes, because Read-write serves exactly the read rows Read-only serves; the EXCLUDED reads
 (audit logs, users, roles, IAM policies, other people's query history, task-run sessions) are
 refused in every mode, so no summary may say "read everything". The line never repeats the mode
-name, which the chip (view) or the slider (edit) already shows. Expanded, it becomes the list heading "Read-write allows", with a
+name, which the chip (view) or the
+selector (edit) already shows. Expanded, it becomes the list heading "Read-write allows", with a
 "Show details" control on the right. In view state it sits under the chip line; in edit state it
-sits under the slider and its "Best for" line, above the masking toggle, so the cause and its
+sits under the selector and its "Best for" line, above the masking toggle, so the cause and its
 effect are adjacent. The open state persists per browser and carries across the view-to-edit
 transition within a page visit.
 
@@ -177,16 +178,22 @@ refusal only when the RPC opts into auditing or the gate marked a policy denial,
 denial on an unannotated method is silent, and "every refusal" would promise more than the backend
 records.
 
-**D5 — Edit state: a slider, the selected mode's "Best for", and the pick's ladder.** The three
-mode cards and their descriptions are gone; they duplicated the ladder. The selector is the shared
-segmented control with three equal-width segments, Disabled · Read-only · Read-write, so the
-control reads as one setting rather than three labels of different sizes. Under it, one line: the
-"Best for" of the selected mode. "Best for" survives because it answers a different question from
-the ladder — who the mode is for — and it is now shown once instead of three times. Under that,
-the disclosure for the picked mode, rendering exactly what the view would show after saving. No
-"adds N over Read-only", no added or removed marks, no comparison against the stored mode: the muted
-rows already show what a pick does not serve. The edit state is about 100 words collapsed and 150
-expanded, down from about 215 and 375 in the first draft of this design.
+**D5 — Edit state: icon cards, the selected mode's "Best for", and the pick's ladder.** The
+three mode cards lose their descriptions; they duplicated the ladder. What remains is the shape of
+the instance engine selector: three bordered cards in a row, each with a Lucide icon, the mode name,
+and a three-word caption — Disabled "No sessions connect", Read-only "Explore and query",
+Read-write "Change data and schemas". The icons are `Unplug`, `Eye` and `PencilLine` from
+`lucide-react`, which the frontend already ships: unplug says nothing connects, in the same
+vocabulary as the Connect a client section below; eye is view only; pencil-line is write. Icons
+are grey and turn accent on the selected card, which also carries the accent border, ring and
+tint; no red, green or amber on the cards, so the mode's color keeps meaning one thing on the chip.
+A label-only card was tried and read empty; the shared segmented control was tried and read as a
+toggle. The caption costs nine words and gives back the at-a-glance comparison the old cards
+provided. Under the cards, one line: the "Best for" of the selected mode, shown once instead of
+three times. Under that, the disclosure for the picked mode, rendering exactly what the view would
+show after saving. No "adds N over Read-only", no added or removed marks, no comparison against the
+stored mode: the muted rows already show what a pick does not serve. The edit state is about 125
+words collapsed and 175 expanded, down from about 215 and 375 in the first draft of this design.
 
 **D6 — Marks: ✓ or —, plus a tier tag on served rows only.** A served row shows ✓, a `success`
 "read" badge or a `warning` "write" badge after its title, and full-contrast text. An unserved row
@@ -194,8 +201,8 @@ shows —, muted text, and no badge. Under Read-only the write rows are unserved
 never appears there.
 
 **D7 — Disabled.** In view, the chip and the sentence "No MCP session can connect to this
-workspace." are the whole answer; no disclosure. In edit with Disabled picked, the slider sits on
-Disabled, the "Best for" line reads "keeping MCP off until you are ready to turn it on", and the
+workspace." are the whole answer; no disclosure. In edit with Disabled picked, the Disabled card is
+selected, the "Best for" line reads "keeping MCP off until you are ready to turn it on", and the
 disclosure slot holds a static line in the floor's soft error tone, "Nothing is allowed; no MCP
 session can connect.", so red means "no capability" everywhere on the card. It is not a button and
 does not repeat the mode name.
@@ -237,8 +244,8 @@ shows no counts, so the frontend needs only the static tier of each row.
 | View · Read-only or Read-write | Chip line with Edit policy; the disclosure line as the description, collapsed. Nothing below it. |
 | View · Disabled | Chip line; "No MCP session can connect to this workspace." No disclosure. |
 | View · unreadable, unserved, read failed | The existing warning or error, unchanged. No disclosure. |
-| Edit · Read-only or Read-write picked | Slider on the pick; the pick's "Best for" line; the disclosure for the pick, collapsed by default, rendering the post-save view, with "Show details" once expanded; masking toggle; separator; footer sentence (naming the change when dirty), Cancel, Save (enabled only when dirty). |
-| Edit · Disabled picked | Slider on Disabled; its "Best for" line; the static soft-error line in the disclosure slot. |
+| Edit · Read-only or Read-write picked | Icon cards with the pick selected; the pick's "Best for" line; the disclosure for the pick, collapsed by default, rendering the post-save view, with "Show details" once expanded; masking toggle; separator; footer sentence (naming the change when dirty), Cancel, Save (enabled only when dirty). |
+| Edit · Disabled picked | Icon cards with Disabled selected; its "Best for" line; the static soft-error line in the disclosure slot. |
 | Consent page | Served row titles with ✓, the ✕ line under Read-only, then the existing constants and caution. |
 
 ## Copy
@@ -255,6 +262,8 @@ All strings, so the change and the locale files have one source. Keys under
   Expanded heading: "{mode} allows". Details control: "Show details" / "Hide details".
 - Disabled — view sentence: "No MCP session can connect to this workspace." Edit static line:
   "Nothing is allowed; no MCP session can connect."
+- Card captions: Disabled "No sessions connect"; Read-only "Explore and query"; Read-write "Change
+  data and schemas".
 - "Best for" lines, unchanged: Disabled "keeping MCP off until you are ready to turn it on";
   Read-only "querying and exploring data, including by people who do not write SQL"; Read-write
   "making database changes through an AI agent, still capped by each user's own permissions".
@@ -278,10 +287,13 @@ All strings, so the change and the locale files have one source. Keys under
 - Disclosure behavior belongs in a shared primitive per the UX contract. There is no
   `Collapsible` in `frontend/src/components/ui/` today; add one wrapping Base UI's Collapsible
   (trigger with `aria-expanded`, panel region) rather than hand-rolling it in the feature.
-- The mode selector is the shared `SegmentedControl` at size `md`. It sizes each segment to its
-  label today; add an equal-width option to the primitive (equal grid columns, or a shared
-  minimum width per segment) rather than styling it in the feature. The `RadioGroup` cards and
-  their `radioClassName` go away.
+- The mode selector keeps the `RadioGroup` and `RadioGroupItem` semantics with the radio hidden
+  (`radioClassName="sr-only"`), and renders each item the way `InstanceEngineRadioGrid` in
+  `InstanceFormBody.tsx` renders an engine: `rounded-sm border px-3 py-2`, selected
+  `border-accent bg-accent/5 ring-1 ring-accent`, hover `border-accent/50`. Each item holds the
+  Lucide icon at `size-5` (`text-control-light`, `text-accent` when selected), the label at
+  body size, and the caption at caption size. Verify the item shows the shared focus ring with the
+  radio hidden.
 - The ladder is an unframed region: the trigger row and the rows are separated by
   `border-block-border` hairlines, with no outer frame, so the change adds no card inside the
   section's existing framed card. (Design mocks draw a light border around the ladder for
@@ -290,7 +302,8 @@ All strings, so the change and the locale files have one source. Keys under
   Disabled static line use the `error` semantic tokens at low opacity; no raw palette colors, no
   `dark:` variants.
 - `MCPAccessPolicySection.tsx`: remove the `Rows3` icon, the in-force string, the mode cards and
-  the mode sentence; render the chip with its aria-label; add the slider and the "Best for" line;
+  the mode sentence; render the chip with its aria-label; strip the mode cards to icon, label and caption and add the
+  "Best for" line under them;
   move the audit sentence to the section description; show the footer sentence only while editing
   and interpolate both modes when dirty; replace the masking copy.
 - `MCPPage.tsx`: remove the Authentication Required alert; extend the Connect a client description.
@@ -301,7 +314,7 @@ All strings, so the change and the locale files have one source. Keys under
   removed, not left empty.
 - Tests: the served set per mode; the disclosure collapsed by default, opens, persists, and follows
   the pick; the details toggle reveals sub-items on every row and persists with the open state; the
-  "Best for" line follows the slider; Disabled renders the static line in edit and the sentence in
+  "Best for" line follows the selection; Disabled renders the static line in edit and the sentence in
   view; the consent page renders the row titles; one e2e case that edits Read-only to Read-write,
   saves, and sees the chip change.
 - Run `node frontend/scripts/check-ui-guideline.mjs`; the change must not add to the legacy
@@ -319,8 +332,8 @@ All strings, so the change and the locale files have one source. Keys under
 
 ## Out of scope
 
-- A custom access policy. When it comes, the rows become checkboxes, the slider becomes a preset
-  picker that selects a prefix, and a policy matching no prefix shows a Custom chip; the backend
+- A custom access policy. When it comes, the rows become checkboxes, the cards become preset
+  buttons that select a prefix, and a policy matching no prefix shows a Custom chip; the backend
   row table is what the gate would read. The ladder needs no redesign. One precondition before
   rows become independently selectable: `SQLService/Export` must be clamped to read statements.
   On MySQL it skips statement validation and the driver executes non-query statements, and the

--- a/docs/design/mcp-capability-ladder.md
+++ b/docs/design/mcp-capability-ladder.md
@@ -161,6 +161,10 @@ description.
 three-stripe icon and the words "In force" are removed. View state reads: the mode chip (success
 for Read-only, warning for Read-write, destructive for Disabled), the "Masking exemptions ignored"
 chip when set, Edit policy on the right; then the disclosure line, which carries the description.
+The mode chip carries the mode's icon before its name — the same Lucide glyph as the card in edit
+state (`Unplug`, `Eye`, `PencilLine`) — so the identity an admin picked is the identity shown in
+force. The chip is the only place the mode's color appears; the cards stay neutral, because a
+control must not look like a status badge and the accent must remain the one selected-state color.
 The separate sentence under the chip is retired for Read-only and Read-write, since the disclosure
 line says the same thing; Disabled keeps its sentence, "No MCP session can connect to this
 workspace.", because it has no list. "Active" was considered and rejected as the label: "Active ·
@@ -226,8 +230,8 @@ approve access in the browser."
 
 **D10 — The consent page uses the row titles.** "This session may" lists the served rows with ✓,
 one ✕ line for the unserved tier under Read-only ("No changes, rollouts or exports"), then the
-existing capped, masking and audit lines. Read-write keeps its caution. One wording table serves
-both surfaces.
+existing capped, masking and audit lines. Read-write keeps its caution. Its mode chip carries the
+same icon as the settings page's. One wording table serves both surfaces.
 
 **D11 — A backend lint binds the wording to the classification.** A table in
 `backend/api/v1/mcp_gate.go` assigns every served method to exactly one row, and a lint in
@@ -302,8 +306,9 @@ All strings, so the change and the locale files have one source. Keys under
   Disabled static line use the `error` semantic tokens at low opacity; no raw palette colors, no
   `dark:` variants.
 - `MCPAccessPolicySection.tsx`: remove the `Rows3` icon, the in-force string, the mode cards and
-  the mode sentence; render the chip with its aria-label; strip the mode cards to icon, label and caption and add the
-  "Best for" line under them;
+  the mode sentence; render the chip with its aria-label and the mode's Lucide icon as its first
+  child at `size-3.5`; strip the mode cards to icon, label and caption and add the "Best for" line
+  under them;
   move the audit sentence to the section description; show the footer sentence only while editing
   and interpolate both modes when dirty; replace the masking copy.
 - `MCPPage.tsx`: remove the Authentication Required alert; extend the Connect a client description.

--- a/docs/design/mcp-capability-ladder.md
+++ b/docs/design/mcp-capability-ladder.md
@@ -66,14 +66,14 @@ mapping; it never appears in the product.
 | Tier | Row | Sub-items shown | Backed by (code only) |
 |---|---|---|---|
 | read | Read schemas and metadata | Schemas · Databases and instances · Projects and database groups · Catalogs, changelogs and revisions · SQL review configs · Your own session and workspace facts | 31 READ methods: `DatabaseService` reads, projects, instances, database groups, catalogs, changelogs, revisions, review configs, session facts |
-| read | Read data by running queries | Run read-only queries; a request is refused whole if any statement is not a read · Query history · Saved queries and sheets | 9 READ methods: `SQLService/Query`, query history (4), saved-query reads (3), `GetSheet` |
+| read | Read data by running queries | Run read-only queries; a request is refused whole if any statement is not a read, and on engines other than PostgreSQL, CockroachDB and Redshift the check is by statement shape only · Query history · Saved queries and sheets | 9 READ methods: `SQLService/Query`, query history (4), saved-query reads (3), `GetSheet` |
 | read | Read the change workflow | Issues and comments · Plans and plan checks · Rollouts, task runs and logs · Releases · Rollback previews | 16 READ methods: issue, plan, rollout and release reads |
 | — | *Read-only stops here* | | 56 methods |
-| write | Propose changes | Create and edit sheets, plans and issues · Run plan checks and reviews · Create, edit and delete releases and revisions · Generate schema diffs. An agent never approves its own change; the project's approval policy decides whether a human must | 22 WRITE methods: sheet, plan, issue, release and revision writes, `RequestIssue`, `RunReview`, `DiffSchema`, `DiffMetadata` |
+| write | Propose changes | Create sheets · Create and edit plans and issues · Run plan checks and reviews · Create and delete releases and revisions · Generate schema diffs. An agent never approves its own change; the project's approval policy decides whether a human must | 22 WRITE methods: sheet, plan, issue, release and revision writes, `RequestIssue`, `RunReview`, `DiffSchema`, `DiffMetadata` |
 | write | Run rollouts and tasks | Create a rollout · Run, skip or cancel its tasks, under the project's approval policy | 4 WRITE methods: `CreateRollout`, `BatchRunTasks`, `BatchSkipTasks`, `BatchCancelTaskRuns` |
 | write | Run DML and DDL statements | INSERT, UPDATE, DELETE, CREATE, ALTER, DROP through queries, where the engine checks each statement and the user may run it | Not a method: the statement clamp in `mcp_sql_clamp.go`, which Read-write lifts |
 | write | Export query results | Download results as a file. Data leaves Bytebase | 1 WRITE method: `SQLService/Export` |
-| write | Manage database housekeeping | Sync instances and databases · Database settings and labels · Database groups · Saved queries | 14 WRITE methods: sync, `UpdateDatabase`, database groups, saved-query writes |
+| write | Manage database housekeeping | Sync instances and databases · Database settings and labels · Move databases between projects · Database groups · Saved queries | 14 WRITE methods: sync, `UpdateDatabase`, database groups, saved-query writes |
 | — | *Read-write stops here* | | 97 methods |
 | floor | Never, in any mode: approve issues, administer the workspace, or handle credentials. | | 121 methods: 35 FORBIDDEN, 86 EXCLUDED |
 
@@ -82,6 +82,18 @@ Two choices in the wording are deliberate. Row 2 says *Read data by running quer
 Read-only. Row 6 is not a method at all: it names the statement clamp being lifted, because that is
 a real difference between the modes that no method name shows, and a future custom policy will want
 it as its own switch.
+
+Every sub-item names only what the served methods can do. Sheets are created, never edited: there
+is no update RPC. Releases and revisions are created and deleted: `ReleaseService/UpdateRelease`
+is classified WRITE but answers Unimplemented, and Revision has no update RPC, so "edit" would
+advertise an operation that does not exist. Moving a database between projects is named under
+housekeeping because `DatabaseService/UpdateDatabase` accepts the `project` mask path and
+`BatchUpdateDatabases` exists for it; it changes a governance boundary and should not hide behind
+"settings and labels". Row 2 states the depth of the read-only check because only PostgreSQL,
+CockroachDB and Redshift open the database session read-only; elsewhere the clamp is statement
+classification alone, and a statement that classifies as a read can still call a function that
+writes. The proto calls the ceiling "classifier-enforced, not proven", and the row says so in the
+admin's words.
 
 Approval is stated as the project's policy, never as a promise. The backend requires an approved
 issue before a rollout only when the project has `require_issue_approval` on and an issue is linked
@@ -124,9 +136,12 @@ The tier is named once, by the dividers, so no row repeats it in its title.
 
 **D1 — Placement: a disclosure inside the Access policy section, collapsed by default.**
 Not a drawer (a second surface, one mode at a time) and not a separate section (it belongs to the
-policy it describes). Collapsed, the trigger line *is* the mode's description: "▸ Read everything,
-and propose, run, export and manage". It never repeats the mode name, which the chip (view) or the
-slider (edit) already shows. Expanded, it becomes the list heading "Read-write allows", with a
+policy it describes). Collapsed, the trigger line *is* the mode's description: "▸ Read schemas, data
+and the change workflow; propose, run, export and manage". The read half is the same phrase in
+both modes, because Read-write serves exactly the read rows Read-only serves; the EXCLUDED reads
+(audit logs, users, roles, IAM policies, other people's query history, task-run sessions) are
+refused in every mode, so no summary may say "read everything". The line never repeats the mode
+name, which the chip (view) or the slider (edit) already shows. Expanded, it becomes the list heading "Read-write allows", with a
 "Show details" control on the right. In view state it sits under the chip line; in edit state it
 sits under the slider and its "Best for" line, above the masking toggle, so the cause and its
 effect are adjacent. The open state persists per browser and carries across the view-to-edit
@@ -156,8 +171,11 @@ request…" shows only while editing, as "Applies to every running session's nex
 names the change when the form is dirty: "Read-only → Read-write applies to every running
 session's next request." "MCP policy denials are recorded in the audit log" is a fact about the
 feature, not about the current state, so it joins the section description, which becomes: "The
-most any MCP session may do here. Sessions are also capped by each user's permissions, and refusals
-are audited."
+most any MCP session may do here. Sessions are also capped by each user's permissions, and policy
+refusals are audited." The word "policy" is load-bearing: the audit interceptor writes a row for a
+refusal only when the RPC opts into auditing or the gate marked a policy denial, so a permission
+denial on an unannotated method is silent, and "every refusal" would promise more than the backend
+records.
 
 **D5 — Edit state: a slider, the selected mode's "Best for", and the pick's ladder.** The three
 mode cards and their descriptions are gone; they duplicated the ladder. The selector is the shared
@@ -230,9 +248,10 @@ All strings, so the change and the locale files have one source. Keys under
 `oauth2.consent.mcp.*` values.
 
 - Section description: "The most any MCP session may do here. Sessions are also capped by each
-  user's permissions, and refusals are audited."
-- Disclosure line, collapsed — Read-only: "Read schemas, data and the change workflow; nothing is
-  written or exported". Read-write: "Read everything, and propose, run, export and manage".
+  user's permissions, and policy refusals are audited."
+- Disclosure line, collapsed — Read-only: "Read schemas, data and the change workflow; statements
+  that write are refused, nothing is exported". Read-write: "Read schemas, data and the change
+  workflow; propose, run, export and manage".
   Expanded heading: "{mode} allows". Details control: "Show details" / "Hide details".
 - Disabled — view sentence: "No MCP session can connect to this workspace." Edit static line:
   "Nothing is allowed; no MCP session can connect."
@@ -302,7 +321,12 @@ All strings, so the change and the locale files have one source. Keys under
 
 - A custom access policy. When it comes, the rows become checkboxes, the slider becomes a preset
   picker that selects a prefix, and a policy matching no prefix shows a Custom chip; the backend
-  row table is what the gate would read. The ladder needs no redesign.
+  row table is what the gate would read. The ladder needs no redesign. One precondition before
+  rows become independently selectable: `SQLService/Export` must be clamped to read statements.
+  On MySQL it skips statement validation and the driver executes non-query statements, and the
+  clamp today lives only in `SQLService/Query`. Under the presets Export is served only alongside
+  the DML/DDL row, so there is no exposure until then. That clamp is an MCP implementation change,
+  tracked separately from this doc.
 - A docs page listing the methods per row, generated from the inventory. Worth doing; not linked
   from the card until it exists.
 - Per-engine read-only depth and masking coverage. The removed drawer showed both; they belong in


### PR DESCRIPTION
Design doc for the MCP settings page: `docs/design/mcp-capability-ladder.md`.

Since #21324 removed the per-mode method drawer, the Access policy section describes each mode in one sentence and nothing on the page says what a mode actually serves. This doc lands on one rule: **show capabilities, not methods or permissions.** Eight capability rows in one ordered list, each mode a prefix of it, collapsed by default inside the existing section, following the picked mode while editing. The page also gets shorter: the mode cards shrink to an icon, a label and a caption with the selected mode's "Best for" under them, the disclosure line is the mode's description, and row details sit behind one toggle. The product change is frontend-only; a backend lint binds the row wording to the method classification so the list cannot drift from what the gate serves. A custom policy is out of scope but the list is shaped to become that editor later.

### What the doc decides

- One verb per tier where it is honest: every read row starts with *Read*. The write tier uses *Propose*, *Run*, *Export*, *Manage*, each naming the row's effect on the database; a single write verb was tried three ways and rejected, with the cases in the doc.
- Rows carry plain sub-items ("Schemas · Databases and instances · Projects and database groups…") behind one "Show details" toggle. No method names, no permission names, no counts, no link to a method list.
- The mode cards shrink to a Lucide icon (unplug · eye · pencil-line), the mode name and a three-word caption, in the shape of the instance engine selector, with the selected mode's "Best for" line under them. The card descriptions are gone; they duplicated the ladder.
- The mode chip is the subject of the view and carries the same Lucide icon as its card; the "In force" label, the stripes icon and the mode sentence go. Color stays on the chip only; the cards stay neutral. The disclosure line carries the description and never repeats the mode name. The tightening note shows only while editing and names the change; the audit fact moves into the section description.
- Edit state renders the picked mode exactly as the post-save view: no delta marks, no "adds N".
- ✓ / — marks with a `read` or `write` badge on served rows only. The floor stays as one short line: "Never, in any mode: approve issues, administer the workspace, or handle credentials."
- Approval is stated as the project's policy, never as a promise (review P1 and P2 on this PR).
- Every line says only what the served methods can do (review round 3): both summaries share the same read phrase, since Read-write serves exactly the reads Read-only serves; Read-only says write statements are refused rather than that nothing is written, and row 2 states the depth of that check; "edit" is dropped where no update RPC exists; moving databases between projects is named; the audit claim is narrowed to policy refusals; the masking toggle keeps its engine-coverage limit.
- Recorded as a precondition for a future custom policy, not changed here: Export must be clamped to read statements before capability rows become independently selectable.
- The Authentication Required alert on the MCP page is removed; its useful clause moves into Connect a client.
- The consent page reuses the row titles.
- Backend: a row table beside `mcpRequestShapeRefusals` and a lint that every served method sits in exactly one row and no refused method in any.

Word budget for the edit state: about 100 words collapsed and 150 expanded, down from about 215 and 375 in the first draft.

### Mockups

Product typography and controls are approximated from the live page.

**A · View, collapsed (the default).** The chip, carrying the mode's icon, then the disclosure line as the description. No "In force", no separate sentence. The audit fact sits in the section description. The Authentication Required box is gone.

<img width="900" alt="A · View, collapsed" src="https://github.com/user-attachments/assets/8c35a154-818a-4ddf-a917-c0880f8e8c9e" />

**B · View, expanded with details shown.** Served rows with ✓ and a `read` badge; unserved rows with — and muted, no badge. "Show details" is on here, so every row's sub-item line is visible. Two dividers and the short floor line.

<img width="900" alt="B · View, expanded" src="https://github.com/user-attachments/assets/bb0c1a66-2449-44ec-9365-7676031bebf9" />

**C · Edit, Read-write picked, collapsed.** Three icon cards with captions, the selected mode's "Best for" under them, then the disclosure line. The masking copy is shorter but keeps the engine-coverage limit (review P1). The footer names the change and enables Save.

<img width="900" alt="C · Edit, collapsed" src="https://github.com/user-attachments/assets/18cd002e-1563-4f3d-82ea-a0a8bca8b73f" />

**D · Edit, Read-write picked, expanded (the default expanded view).** Titles and tier tags only, with "Show details" on the right. Picking Read-only renders the same list with the write rows muted, so there is no separate tightening view.

<img width="900" alt="D · Edit, expanded" src="https://github.com/user-attachments/assets/bd38da15-ce63-4425-9676-2056491d9ee9" />

**E · Disabled.** Above: the view, where the chip and one sentence are the whole answer. Below: the edit state with Disabled picked, its "Best for" line, and the static line in the floor's soft red.

<img width="900" alt="E · Disabled" src="https://github.com/user-attachments/assets/3ff9bcd3-0f39-436b-b129-8db95c01f2a7" />

**F · Unreadable stored policy.** The existing repair state, unchanged. No disclosure.

<img width="900" alt="F · Unreadable" src="https://github.com/user-attachments/assets/2ff38dc5-1d57-432b-9229-5c766d5553eb" />

**G · Consent page.** The same row titles under "This session may", one line for the unserved tier, then the existing constants.

<img width="900" alt="G · Consent" src="https://github.com/user-attachments/assets/7d6c5140-4954-4740-8e28-e93626126814" />

### Not in this PR

Implementation follows in a separate PR: the `MCPCapabilityLadder` component, a shared `Collapsible` primitive, the icon cards on the existing radio group, the copy and locale changes, the consent page, the alert removal, and the backend row table with its lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
