### PR TITLE
perf(ci): tune golangci-lint GC to cut CPU and cap RSS

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -52,9 +52,10 @@ jobs:
       - name: golangci-lint
         env:
           # Go's default GOGC=100 collects every time a ~5 GB live heap doubles, which
-          # is the wrong policy for a batch run. Collecting only near a ceiling instead
-          # is cheaper on all three axes, and the ceiling bounds what two concurrent
-          # runners can take from the shared 31 GB box.
+          # is the wrong policy for a batch run. Collecting near a target instead is
+          # cheaper on CPU, wall and peak RSS alike. GOMEMLIMIT is a soft limit over
+          # Go-managed memory, not a guaranteed RSS ceiling, but it holds in practice
+          # here: 10.17 GB peak measured, against 11.05 GB with the default.
           GOGC: "off"
           GOMEMLIMIT: 10GiB
         run: golangci-lint run --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -50,4 +50,11 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
+        env:
+          # Go's default GOGC=100 collects every time a ~5 GB live heap doubles, which
+          # is the wrong policy for a batch run. Collecting only near a ceiling instead
+          # is cheaper on all three axes, and the ceiling bounds what two concurrent
+          # runners can take from the shared 31 GB box.
+          GOGC: "off"
+          GOMEMLIMIT: 10GiB
         run: golangci-lint run --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ During iteration, run focused checks for the changed behavior. Before handoff, r
 ### Go changes
 
 1. Run `gofmt -w` on modified Go files.
-2. Run `GOGC=off GOMEMLIMIT=10GiB golangci-lint run --fix -j 8 --allow-parallel-runners`, then the same command without `--fix` until clean after corrections. Run at repo root without filenames so package context is available. Keep the flags: on a cold cache they take the run from ~730 to ~420 CPU-seconds and cap peak RSS at the limit, on a box shared with two CI runners.
+2. Run `GOGC=off GOMEMLIMIT=10GiB golangci-lint run --fix -j 8 --allow-parallel-runners`, then the same command without `--fix` until clean after corrections. Run at repo root without filenames so package context is available. Keep the flags: on a cold cache they take the run from ~730 to ~420 CPU-seconds and hold peak RSS near 10 GB, on a box shared with two CI runners.
 3. Run tests for changed packages and affected behavior, including required collision or contention coverage.
 4. Build: `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`.
 5. After dependency changes, run `go mod tidy` and recheck affected code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ During iteration, run focused checks for the changed behavior. Before handoff, r
 ### Go changes
 
 1. Run `gofmt -w` on modified Go files.
-2. Run `golangci-lint run --fix -j 8 --allow-parallel-runners`, then `golangci-lint run -j 8 --allow-parallel-runners` until clean after corrections. Run at repo root without filenames so package context is available. Keep `-j 8`: on a cold cache it trades ~15s of wall time for ~30% less CPU and ~1.5 GB less peak RSS on the shared box.
+2. Run `GOGC=off GOMEMLIMIT=10GiB golangci-lint run --fix -j 8 --allow-parallel-runners`, then the same command without `--fix` until clean after corrections. Run at repo root without filenames so package context is available. Keep the flags: on a cold cache they take the run from ~730 to ~420 CPU-seconds and cap peak RSS at the limit, on a box shared with two CI runners.
 3. Run tests for changed packages and affected behavior, including required collision or contention coverage.
 4. Build: `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`.
 5. After dependency changes, run `go mod tidy` and recheck affected code.


### PR DESCRIPTION
## What

Sets `GOGC=off` and `GOMEMLIMIT=10GiB` for the golangci-lint step in CI, and on the documented local command. Follow-up to #21395, which found where the CPU actually goes.

Go's default `GOGC=100` collects every time the heap doubles. golangci-lint holds a **~5 GB live heap** on this repo, so the default spends a large share of its CPU repeatedly scanning it. Collecting only as the heap approaches a ceiling is cheaper — and the ceiling is a real bound on memory, where `-j` only ever influenced it indirectly.

## Measurements

Runner box (20 vCPU / 31 GB), `-j 8`, golangci cache cleared before each run, all runs started at load < 1.5:

| setting | CPU | wall | peak RSS |
|---|---|---|---|
| **`GOGC` default (100)** — today | 491s | 65.6s | 11.05 GB |
| `GOGC=off GOMEMLIMIT=8GiB` | 449s | 61.1s | 8.22 GB |
| **`GOGC=off GOMEMLIMIT=10GiB`** ← this PR | **418s** | **57.2s** | **10.22 GB** |
| `GOGC=off GOMEMLIMIT=12GiB` | 397s | 55.0s | 12.43 GB |
| `GOGC=off GOMEMLIMIT=16GiB` | 375s | 53.1s | 15.99 GB |
| `GOGC=400`, no limit | 388s | 57.6s | **27.25 GB** ⚠️ |

10GiB beats today's default on **all three axes**: 15% less CPU, 13% less wall, 8% less peak RSS. It also lowers the worst-case ceiling, which matters because two runners share the box — `2 x 10GiB` leaves headroom for the frontend and backend-test jobs.

Bare `GOGC=400` reaches similar CPU but peaks at 27 GB on a 31 GB box. The limit is doing the safety work here, not the GOGC value.

Combined with the `-j 8` from #21395, a cold run goes from ~730 CPU-seconds at the stock defaults to ~420 — about 43% less, with no checks dropped.

## Trade-off

With GC effectively deferred, a **warm** run's peak RSS goes from ~0.18 GB to ~1.24 GB (measured, 2 reps each). Wall time is unchanged at ~2.6s. Trivial in absolute terms, but it is a real 7x on the common case, so it is worth knowing.

## What I ruled out

Where the CPU actually is, same conditions:

| variant | CPU | vs baseline |
|---|---|---|
| baseline | 493s | — |
| drop `staticcheck` + `unused` | 181s | **-63%** |
| drop `exhaustive` | 477s | -3% |
| drop `revive` + `gocritic` | 471s | -4% |

`buildir` — staticcheck's IR builder, feeding `staticcheck` and `unused` — is 46% of analyzer CPU by itself. Those two are the highest-value linters in the config, so this PR does not touch them; trimming anything else is noise.

`--tests=false` looked tempting (407s, -17%) but made `unused` report **50 false positives**, since code used only by tests looks dead. Not viable.

`-j 8` is already near-optimal: j=4 → 595s, j=6 → 476s, j=8 → 493s, j=12 → 654s, j=20 → 732s.

The remaining big lever is cache persistence — a cold run is 2:47 / 2530 CPU-s / 12.9 GB against 2.9s / 20 CPU-s / 0.19 GB warm, because `/scratch` is GCE Local SSD and every Spot preemption wipes it. That lives in the devbox startup script, not this repo.

## Test plan

- [x] YAML parses `GOGC` as the string `"off"`, not a boolean — verified with a parser
- [x] Runtime honors it: `debug.SetGCPercent` reports `-1`, `debug.SetMemoryLimit` reports `10.00 GiB`
- [x] Cold run under the new env peaks at 10.17 GB, i.e. the cap holds
- [x] `golangci-lint run` reports `0 issues.`; both documented commands run verbatim and `--fix` touches no files
- [x] Pre-PR checklist: sections 3-6 and 8 skip (no `backend/store`, `migrator`, `tests`, proto or code changes); section 2 does not apply — CI env is not user-facing configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)