### PR TITLE
fix(taskrun): roll back leaked test transactions

### DIFF
--- a/backend/runner/taskrun/running_scheduler_test.go
+++ b/backend/runner/taskrun/running_scheduler_test.go
@@ -167,6 +167,7 @@ func TestValidateTaskFreshnessChecksInstanceArchival(t *testing.T) {
 
 	tx, err := s.GetDB().BeginTx(ctx, nil)
 	require.NoError(t, err)
+	defer tx.Rollback()
 	tasks, err := s.CreateMissingTasksTx(ctx, tx, plan.ProjectID, plan.UID, []*store.TaskMessage{{
 		InstanceID: instanceID,
 		Type:       storepb.Task_DATABASE_CREATE,
@@ -214,6 +215,7 @@ func TestScheduleRunningTaskRunsSkipsArchivedInstance(t *testing.T) {
 
 	tx, err := s.GetDB().BeginTx(ctx, nil)
 	require.NoError(t, err)
+	defer tx.Rollback()
 	tasks, err := s.CreateMissingTasksTx(ctx, tx, plan.ProjectID, plan.UID, []*store.TaskMessage{{
 		InstanceID: instanceID,
 		Type:       storepb.Task_DATABASE_CREATE,

--- a/backend/runner/taskrun/scheduler_test.go
+++ b/backend/runner/taskrun/scheduler_test.go
@@ -33,6 +33,10 @@ func TestTaskCyclesRecordEmptySuccess(t *testing.T) {
 	require.NoError(t, scheduler.scheduleRunningTaskRuns(ctx))
 	tx, err := stores.GetDB().BeginTx(ctx, nil)
 	require.NoError(t, err)
+	// The explicit Rollback below is what releases the advisory lock. This guards the
+	// path where a require between here and there calls t.FailNow: that skips the
+	// explicit Rollback and would strand the lock for the rest of the package.
+	defer tx.Rollback()
 	acquired, err := store.TryAdvisoryXactLock(ctx, tx, store.AdvisoryLockKeyPendingScheduler)
 	require.NoError(t, err)
 	require.True(t, acquired)
@@ -118,6 +122,7 @@ func TestSchedulePendingTaskRunsSkipsArchivedProject(t *testing.T) {
 
 	tx, err := s.GetDB().BeginTx(ctx, nil)
 	require.NoError(t, err)
+	defer tx.Rollback()
 	tasks, err := s.CreateMissingTasksTx(ctx, tx, plan.ProjectID, plan.UID, []*store.TaskMessage{{
 		InstanceID: "unused",
 		Type:       storepb.Task_TASK_TYPE_UNSPECIFIED,
@@ -184,6 +189,7 @@ func TestSchedulePendingTaskRunsSkipsArchivedInstance(t *testing.T) {
 
 	tx, err := s.GetDB().BeginTx(ctx, nil)
 	require.NoError(t, err)
+	defer tx.Rollback()
 	tasks, err := s.CreateMissingTasksTx(ctx, tx, plan.ProjectID, plan.UID, []*store.TaskMessage{{
 		InstanceID: instanceID,
 		Type:       storepb.Task_TASK_TYPE_UNSPECIFIED,


### PR DESCRIPTION
## What

Five tests in `backend/runner/taskrun` open a transaction and reach `Commit` (or an explicit `Rollback`) **on the happy path only**:

```go
tx, err := s.GetDB().BeginTx(ctx, nil)
require.NoError(t, err)
tasks, err := s.CreateMissingTasksTx(ctx, tx, ...)
require.NoError(t, err)          // <- t.FailNow here skips the Commit below
require.Len(t, tasks, 1)         // <- and here
require.NoError(t, tx.Commit())
```

`require.*` failure calls `t.FailNow`, which runs `runtime.Goexit` and skips both the commit and any rollback. The transaction is never closed.

The connection is not reclaimed afterwards either. `database/sql`'s `beginDC` derives the Tx context with `context.WithCancel` and only cancels it from `Commit`/`Rollback`; with `context.Background()` as the parent, nothing else ever fires `awaitDone`. **The connection stays checked out until the test binary exits.** (Had these used `t.Context()`, the leak would self-heal at test end.)

| site | before |
|---|---|
| `scheduler_test.go:34` | `tx.Rollback()` present but not deferred |
| `scheduler_test.go:119` | no rollback |
| `scheduler_test.go:185` | no rollback |
| `running_scheduler_test.go:168` | no rollback |
| `running_scheduler_test.go:215` | no rollback |

## Why line 34 is the damaging one

That transaction holds `AdvisoryLockKeyPendingScheduler` — the same key [`pending_scheduler.go:75`](backend/runner/taskrun/pending_scheduler.go#L75) acquires in production. A stranded lock makes every later test in the package that runs the pending scheduler take the `"advisory lock held by another replica, skipping"` path. Those tests then **pass without exercising anything**, so one failure quietly turns the rest of the package green-but-meaningless.

## Fix

A deferred `tx.Rollback()` at each site. `Goexit` does run deferred calls, so this closes every path; the rollback after a successful commit returns `sql.ErrTxDone`, which is discarded.

## How they were found

An AST scan pairing every acquisition (`BeginTx`, `Begin`, `Conn`, `Acquire`) with its release across `backend`, `action` and `scripts`, following closure-form defers and ownership transfer.

**All 73 production `BeginTx` sites already defer a rollback** — most via `defer func(){ tx.Rollback() }()`, which a naive grep misses. Connection handling is sound too: `advisory_lock.go` closes on every error path and transfers ownership on success, `AdminExecute` has `defer clean()`, and the `driverConn.(*stdlib.Conn).Conn()` sites are accessors rather than acquisitions. These five tests were the only unpaired acquisitions in the tree.

## Test plan

- [x] `go test -count=1 ./backend/runner/taskrun/ -timeout 15m` — passes
- [x] The five affected tests pass individually
- [x] `gofmt -l` clean; `golangci-lint run -j 8` → `0 issues.`
- [x] Re-ran the AST scan — no unpaired acquisitions remain in `backend/runner/taskrun`
- [x] Verified the load-bearing assumption directly: a `defer` still runs after `t.FailNow()`
- [x] Pre-PR checklist: section 2 skips (test files only); sections 3-6 skip (no `backend/store`, `backend/migrator`, `backend/tests`, no pagination or store transaction changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)