### PR TITLE
fix(masking): refuse a query whose table has no synced columns

### DIFF
--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -61,18 +61,8 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		if results[i].Error == "" && spans[i].NotFoundError != nil {
 			return errors.Errorf("masking error: %v", spans[i].NotFoundError)
 		}
-		// queryRetry re-syncs and rebuilds the span before this runs, so a span
-		// still carrying the signal here means a fresh sync could not describe the
-		// relation. The refusal has to precede getMaskersForQuerySpan below: a
-		// driver can return rows and an error together (MaximumSQLResultSize sets
-		// Error on the rows collected so far), and the redaction branch between
-		// them takes only zero-row results, so those partial rows would otherwise
-		// be handed to doMaskResult with no maskers. Sitting above that branch as
-		// well refuses an errored zero-row result rather than redacting it. A table
-		// PostgreSQL legally leaves without columns is stored identically and
-		// refused too, permanently: CREATE TABLE t() and dropping a table's last
-		// column both produce it, and the syncer's column query skips dropped
-		// attributes, so a re-sync reproduces it.
+		// Reject before error handling or masking: results may contain both partial
+		// rows and an error, and unresolved lineage cannot safely mask those rows.
 		if maskingBlockedByUnresolvedColumns(spans[i], instance) {
 			return errors.Errorf(
 				"masking cannot be applied: %v, so the query was not returned",
@@ -87,9 +77,7 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		if results[i].Error != "" && len(results[i].Rows) == 0 {
 			if i < len(spans) && spans[i] != nil && s.spanTouchesMaskedColumns(ctx, m, instance, user, spans[i]) {
 				results[i].Error = "Query execution failed. Error details are hidden because the query references columns with data masking policies."
-				// The driver also fills DetailedError with the raw PostgreSQL error
-				// fields, InternalQuery among them, which carries the failing SQL
-				// text. Those reach the client whatever Error says.
+				// Structured error fields can contain sensitive values and SQL too.
 				results[i].DetailedError = nil
 			}
 			continue
@@ -104,12 +92,8 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 	return nil
 }
 
-// maskingBlockedByUnresolvedColumns reports whether masking cannot be evaluated
-// for this span because the stored snapshot does not describe a relation the
-// query reads. The re-sync trigger in queryRetry and the refusal above must key
-// on this one predicate: a re-sync firing where the refusal will not is wasted
-// work on the request path, and a refusal firing where the re-sync did not never
-// gives a stale snapshot its chance to recover.
+// maskingBlockedByUnresolvedColumns keeps the re-sync trigger and masking
+// refusal on the same condition, so stale metadata gets a chance to recover.
 func maskingBlockedByUnresolvedColumns(span *parserbase.QuerySpan, instance *store.InstanceMessage) bool {
 	if span == nil || span.UnresolvedColumnsError == nil || instance == nil {
 		return false

--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -61,6 +61,23 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		if results[i].Error == "" && spans[i].NotFoundError != nil {
 			return errors.Errorf("masking error: %v", spans[i].NotFoundError)
 		}
+		// queryRetry re-syncs and rebuilds the span before this runs, so a span
+		// still carrying the signal here means a fresh sync could not describe the
+		// relation. The refusal has to precede getMaskersForQuerySpan below: a
+		// driver can return rows and an error together (MaximumSQLResultSize sets
+		// Error on the rows collected so far), and the redaction branch between
+		// them takes only zero-row results, so those partial rows would otherwise
+		// be handed to doMaskResult with no maskers. Sitting above that branch as
+		// well refuses an errored zero-row result rather than redacting it. A table
+		// PostgreSQL legally leaves without columns is stored identically and
+		// refused too, permanently: CREATE TABLE t() and dropping a table's last
+		// column both produce it, and the syncer's column query skips dropped
+		// attributes, so a re-sync reproduces it.
+		if maskingBlockedByUnresolvedColumns(spans[i], instance) {
+			return errors.Errorf(
+				"masking cannot be applied: %v, so the query was not returned",
+				spans[i].UnresolvedColumnsError)
+		}
 		// Skip masking for error result, but redact the error message if the
 		// statement touches masked columns — database errors can contain
 		// actual column values (e.g. "invalid input syntax for type integer: '<value>'").
@@ -70,6 +87,10 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		if results[i].Error != "" && len(results[i].Rows) == 0 {
 			if i < len(spans) && spans[i] != nil && s.spanTouchesMaskedColumns(ctx, m, instance, user, spans[i]) {
 				results[i].Error = "Query execution failed. Error details are hidden because the query references columns with data masking policies."
+				// The driver also fills DetailedError with the raw PostgreSQL error
+				// fields, InternalQuery among them, which carries the failing SQL
+				// text. Those reach the client whatever Error says.
+				results[i].DetailedError = nil
 			}
 			continue
 		}
@@ -81,6 +102,19 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 	}
 
 	return nil
+}
+
+// maskingBlockedByUnresolvedColumns reports whether masking cannot be evaluated
+// for this span because the stored snapshot does not describe a relation the
+// query reads. The re-sync trigger in queryRetry and the refusal above must key
+// on this one predicate: a re-sync firing where the refusal will not is wasted
+// work on the request path, and a refusal firing where the re-sync did not never
+// gives a stale snapshot its chance to recover.
+func maskingBlockedByUnresolvedColumns(span *parserbase.QuerySpan, instance *store.InstanceMessage) bool {
+	if span == nil || span.UnresolvedColumnsError == nil || instance == nil {
+		return false
+	}
+	return common.EngineSupportMasking(instance.Metadata.GetEngine())
 }
 
 // spanTouchesMaskedColumns checks whether any column referenced anywhere in

--- a/backend/api/v1/query_result_masker_test.go
+++ b/backend/api/v1/query_result_masker_test.go
@@ -1,0 +1,101 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func instanceOn(engine storepb.Engine) *store.InstanceMessage {
+	return &store.InstanceMessage{
+		ResourceID: "inst",
+		Metadata:   &storepb.Instance{Engine: engine},
+	}
+}
+
+func unresolvedSpan() *parserbase.QuerySpan {
+	return &parserbase.QuerySpan{
+		Type: parserbase.Select,
+		UnresolvedColumnsError: &parserbase.UnresolvedColumnsError{
+			Relations: []parserbase.ColumnResource{
+				{Database: "db", Schema: "public", Table: "t"},
+			},
+		},
+	}
+}
+
+// TestMaskingBlockedByUnresolvedColumns pins the single predicate behind both
+// the re-sync trigger in queryRetry and the refusal in MaskResults; why they
+// must agree is at the function itself.
+func TestMaskingBlockedByUnresolvedColumns(t *testing.T) {
+	testCases := []struct {
+		name     string
+		span     *parserbase.QuerySpan
+		instance *store.InstanceMessage
+		want     bool
+	}{
+		{
+			name:     "unresolved columns on a masking engine blocks",
+			span:     unresolvedSpan(),
+			instance: instanceOn(storepb.Engine_POSTGRES),
+			want:     true,
+		},
+		{
+			// CockroachDB shares the PostgreSQL span extractor, so it receives the
+			// signal, but it never masks. Acting on it would sync per query and
+			// then refuse nothing.
+			name:     "engine that never masks does not block",
+			span:     unresolvedSpan(),
+			instance: instanceOn(storepb.Engine_COCKROACHDB),
+			want:     false,
+		},
+		{
+			name:     "resolved span does not block",
+			span:     &parserbase.QuerySpan{Type: parserbase.Select},
+			instance: instanceOn(storepb.Engine_POSTGRES),
+			want:     false,
+		},
+		{
+			name:     "nil span does not block",
+			span:     nil,
+			instance: instanceOn(storepb.Engine_POSTGRES),
+			want:     false,
+		},
+		{
+			name:     "nil instance does not block",
+			span:     unresolvedSpan(),
+			instance: nil,
+			want:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, maskingBlockedByUnresolvedColumns(tc.span, tc.instance))
+		})
+	}
+}
+
+// TestMaskingEnginesAgreeWithSignalProducers pins that enforcement keys on
+// EngineSupportMasking rather than on the one engine that produces the signal
+// today. Narrowing the predicate to POSTGRES passes every other test in this
+// package, so this is the only thing standing between a later edit and an
+// engine-specific gate. Add an engine as it gains a producer, so the remaining
+// gap stays visible rather than being inferred from a missing test.
+func TestMaskingEnginesAgreeWithSignalProducers(t *testing.T) {
+	// Masking engines whose extractors do not set the signal yet. They must block
+	// once one does; POSTGRES and COCKROACHDB are covered by the table above.
+	for _, engine := range []storepb.Engine{
+		storepb.Engine_MYSQL,
+		storepb.Engine_ORACLE,
+		storepb.Engine_MSSQL,
+		storepb.Engine_REDSHIFT,
+	} {
+		require.True(t, maskingBlockedByUnresolvedColumns(unresolvedSpan(), instanceOn(engine)),
+			"%s masks, so it must act on the signal once its extractor sets one", engine)
+	}
+}

--- a/backend/api/v1/query_result_masker_test.go
+++ b/backend/api/v1/query_result_masker_test.go
@@ -28,9 +28,6 @@ func unresolvedSpan() *parserbase.QuerySpan {
 	}
 }
 
-// TestMaskingBlockedByUnresolvedColumns pins the single predicate behind both
-// the re-sync trigger in queryRetry and the refusal in MaskResults; why they
-// must agree is at the function itself.
 func TestMaskingBlockedByUnresolvedColumns(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -45,9 +42,7 @@ func TestMaskingBlockedByUnresolvedColumns(t *testing.T) {
 			want:     true,
 		},
 		{
-			// CockroachDB shares the PostgreSQL span extractor, so it receives the
-			// signal, but it never masks. Acting on it would sync per query and
-			// then refuse nothing.
+			// CockroachDB shares the PostgreSQL extractor but does not support masking.
 			name:     "engine that never masks does not block",
 			span:     unresolvedSpan(),
 			instance: instanceOn(storepb.Engine_COCKROACHDB),
@@ -80,15 +75,8 @@ func TestMaskingBlockedByUnresolvedColumns(t *testing.T) {
 	}
 }
 
-// TestMaskingEnginesAgreeWithSignalProducers pins that enforcement keys on
-// EngineSupportMasking rather than on the one engine that produces the signal
-// today. Narrowing the predicate to POSTGRES passes every other test in this
-// package, so this is the only thing standing between a later edit and an
-// engine-specific gate. Add an engine as it gains a producer, so the remaining
-// gap stays visible rather than being inferred from a missing test.
+// These engines must enforce the signal once their extractors produce it.
 func TestMaskingEnginesAgreeWithSignalProducers(t *testing.T) {
-	// Masking engines whose extractors do not set the signal yet. They must block
-	// once one does; POSTGRES and COCKROACHDB are covered by the table above.
 	for _, engine := range []storepb.Engine{
 		storepb.Engine_MYSQL,
 		storepb.Engine_ORACLE,

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -744,13 +744,8 @@ func queryRetry(
 		if i >= len(spans) {
 			continue
 		}
-		// Re-sync before treating the condition as real: a snapshot written while
-		// the connecting role lacked privileges repairs itself here.
-		// DEFER: nothing bounds the retry, so a permanently column-less table runs
-		// a full sync on every query; upgrade when BYT-10074 lands.
-		// This sits above the error skip because
-		// MaskResults refuses whatever the result shape; skipping a size-limited
-		// result here would refuse it without ever syncing.
+		// Re-sync even for error results: MaskResults also refuses partial rows.
+		// Permanently empty tables re-sync on every query until BYT-10074 adds throttling.
 		if maskingEnabled && maskingBlockedByUnresolvedColumns(spans[i], instance) {
 			for _, dbName := range spans[i].UnresolvedColumnsError.Databases() {
 				slog.Debug("database metadata need to sync: unresolved columns",
@@ -779,12 +774,7 @@ func queryRetry(
 			return nil, nil, duration, err
 		}
 		if d == nil {
-			// The referenced database is not tracked by Bytebase (e.g. it was
-			// dropped, excluded by sync filters, or never discovered yet).
-			// Skip the sync attempt and leave the span's error in place, whether
-			// that is NotFoundError or the unresolved-columns signal, so the
-			// masking policy below can reject the query cleanly instead of
-			// panicking on a nil *DatabaseMessage.
+			// Leave the span error in place so masking can reject an untracked database.
 			slog.Debug("skip metadata sync: database not tracked",
 				slog.String("instance", instance.ResourceID),
 				slog.String("database", accessDatabaseName))

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -741,10 +741,29 @@ func queryRetry(
 
 	syncDatabaseMap := make(map[string]bool)
 	for i, r := range results {
+		if i >= len(spans) {
+			continue
+		}
+		// Re-sync before treating the condition as real: a snapshot written while
+		// the connecting role lacked privileges repairs itself here.
+		// DEFER: nothing bounds the retry, so a permanently column-less table runs
+		// a full sync on every query; upgrade when BYT-10074 lands.
+		// This sits above the error skip because
+		// MaskResults refuses whatever the result shape; skipping a size-limited
+		// result here would refuse it without ever syncing.
+		if maskingEnabled && maskingBlockedByUnresolvedColumns(spans[i], instance) {
+			for _, dbName := range spans[i].UnresolvedColumnsError.Databases() {
+				slog.Debug("database metadata need to sync: unresolved columns",
+					slog.String("instance", instance.ResourceID),
+					slog.String("database", dbName),
+					slog.String("detail", spans[i].UnresolvedColumnsError.Error()))
+				syncDatabaseMap[dbName] = true
+			}
+		}
 		if r.Error != "" {
 			continue
 		}
-		if i < len(spans) && spans[i].NotFoundError != nil {
+		if spans[i].NotFoundError != nil {
 			for k := range spans[i].SourceColumns {
 				slog.Debug("database metadata need to sync", slog.String("instance", instance.ResourceID), slog.String("database", k.Database), slog.String("schema", k.Schema), slog.String("table", k.Table), slog.String("column", k.Column))
 				syncDatabaseMap[k.Database] = true
@@ -762,9 +781,10 @@ func queryRetry(
 		if d == nil {
 			// The referenced database is not tracked by Bytebase (e.g. it was
 			// dropped, excluded by sync filters, or never discovered yet).
-			// Skip the sync attempt and leave the span's NotFoundError in place
-			// so the masking policy below can reject the query cleanly instead
-			// of panicking on a nil *DatabaseMessage.
+			// Skip the sync attempt and leave the span's error in place, whether
+			// that is NotFoundError or the unresolved-columns signal, so the
+			// masking policy below can reject the query cleanly instead of
+			// panicking on a nil *DatabaseMessage.
 			slog.Debug("skip metadata sync: database not tracked",
 				slog.String("instance", instance.ResourceID),
 				slog.String("database", accessDatabaseName))

--- a/backend/plugin/parser/base/span.go
+++ b/backend/plugin/parser/base/span.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -73,6 +74,45 @@ type QuerySpan struct {
 	ElasticsearchAnalysis     *ElasticsearchAnalysis
 	NotFoundError             error
 	FunctionNotSupportedError error
+	// UnresolvedColumnsError is set when the query reads a relation the stored
+	// snapshot describes no columns for. Masking is column-granular, so a
+	// consumer that masks must read it as "cannot evaluate" rather than "nothing
+	// to mask"; one that does not mask can ignore it, the span is otherwise
+	// usable.
+	UnresolvedColumnsError *UnresolvedColumnsError
+}
+
+// UnresolvedColumnsError names those relations. A sync that ran while the
+// connecting role lacked privileges is the usual cause: the relation is still
+// listed, with no columns under it.
+type UnresolvedColumnsError struct {
+	// Relations each carry an empty Column field.
+	Relations []ColumnResource
+}
+
+func (e *UnresolvedColumnsError) Error() string {
+	names := make([]string, 0, len(e.Relations))
+	for _, r := range e.Relations {
+		names = append(names, r.String())
+	}
+	slices.Sort(names)
+	return fmt.Sprintf("the synced schema describes no columns for %s", strings.Join(names, ", "))
+}
+
+// Databases names only the databases holding an unresolved relation, so a
+// caller can re-sync those rather than every database the query reads.
+func (e *UnresolvedColumnsError) Databases() []string {
+	seen := make(map[string]bool, len(e.Relations))
+	var out []string
+	for _, r := range e.Relations {
+		if r.Database == "" || seen[r.Database] {
+			continue
+		}
+		seen[r.Database] = true
+		out = append(out, r.Database)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // QuerySpanResult is the result column of a query span.

--- a/backend/plugin/parser/base/span.go
+++ b/backend/plugin/parser/base/span.go
@@ -74,17 +74,12 @@ type QuerySpan struct {
 	ElasticsearchAnalysis     *ElasticsearchAnalysis
 	NotFoundError             error
 	FunctionNotSupportedError error
-	// UnresolvedColumnsError is set when the query reads a relation the stored
-	// snapshot describes no columns for. Masking is column-granular, so a
-	// consumer that masks must read it as "cannot evaluate" rather than "nothing
-	// to mask"; one that does not mask can ignore it, the span is otherwise
-	// usable.
+	// UnresolvedColumnsError prevents masking consumers from treating missing
+	// column metadata as an absence of masking policies. Other consumers may ignore it.
 	UnresolvedColumnsError *UnresolvedColumnsError
 }
 
-// UnresolvedColumnsError names those relations. A sync that ran while the
-// connecting role lacked privileges is the usual cause: the relation is still
-// listed, with no columns under it.
+// UnresolvedColumnsError identifies relations whose synced metadata has no columns.
 type UnresolvedColumnsError struct {
 	// Relations each carry an empty Column field.
 	Relations []ColumnResource
@@ -99,8 +94,7 @@ func (e *UnresolvedColumnsError) Error() string {
 	return fmt.Sprintf("the synced schema describes no columns for %s", strings.Join(names, ", "))
 }
 
-// Databases names only the databases holding an unresolved relation, so a
-// caller can re-sync those rather than every database the query reads.
+// Databases returns the sorted, distinct database names that need re-syncing.
 func (e *UnresolvedColumnsError) Databases() []string {
 	seen := make(map[string]bool, len(e.Relations))
 	var out []string

--- a/backend/plugin/parser/pg/access_tables.go
+++ b/backend/plugin/parser/pg/access_tables.go
@@ -129,7 +129,7 @@ func (a *accessTableExtractor) processRangeVar(rv *ast.RangeVar) {
 		if databaseMetadata == nil {
 			return
 		}
-		schemaName, name := databaseMetadata.SearchObject(searchPath, resource.Table)
+		schemaName, name := databaseMetadata.SearchRelation(searchPath, resource.Table)
 		if schemaName == "" && name == "" {
 			return
 		}

--- a/backend/plugin/parser/pg/backup.go
+++ b/backend/plugin/parser/pg/backup.go
@@ -385,7 +385,7 @@ func extractTableReferenceFromRangeVar(rv *ast.RangeVar, metadata *model.Databas
 		if len(searchPath) == 0 {
 			searchPath = []string{"public"}
 		}
-		schemaName, _ := metadata.SearchObject(searchPath, rv.Relname)
+		schemaName, _ := metadata.SearchRelation(searchPath, rv.Relname)
 		if schemaName == "" {
 			return nil, errors.Errorf("Table %q not found in metadata with search path %v", rv.Relname, searchPath)
 		}

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -182,29 +182,9 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 	return "", 0, 0
 }
 
-// unresolvedColumnsError reports the relations in accesses that the stored
-// snapshot lists with no columns, or nil when every one resolves. It reads the
-// snapshot rather than analyzer
-// output, so the analyzed, expression-fallback and table-returning-function
-// paths all report the same condition.
-//
-// Every access is checked, including one naming a CTE that shares a listed
-// relation's name: ExtractAccessTables does not model CTE scope, so such a query
-// is refused rather than passed. Do not filter this set by CTE scope. A filter
-// can only drop a refusal, and a scope walk drops real reads — it misses an
-// aggregate's FILTER and ORDER BY subqueries and folds case on quoted CTE names,
-// each one a query returning unmasked rows.
-//
-// DEFER: a relation the access set never reports goes unchecked and stays
-// unmasked. A relation absent from the snapshot has no ceiling to raise here;
-// column resolution drops it upstream. The two reachable gaps are a
-// SQL-language function body (BYT-10075) and a FROM-clause function argument or
-// VALUES list (BYT-10076); upgrade when either ticket lands.
-//
-// #20581 (3.19.1) made the sync read columns from pg_catalog, so privileges no
-// longer produce this state; a snapshot written before that fix still carries it,
-// and the sync's read-committed transaction can still store a table created
-// between its column pass and its table pass with no columns.
+// unresolvedColumnsError checks stored metadata independently of column lineage.
+// Accesses are conservative: CTE names can match physical tables, so this may
+// refuse a CTE-only query. Reads missing from the access set remain unchecked.
 func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet) *base.UnresolvedColumnsError {
 	seen := make(map[base.ColumnResource]bool, len(accesses))
 	var unresolved []base.ColumnResource
@@ -229,16 +209,10 @@ func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColu
 	return &base.UnresolvedColumnsError{Relations: unresolved}
 }
 
-// relationHasNoSyncedColumns reports whether the snapshot carries the relation
-// as a table with an empty column list, and false for anything else.
-//
-// Only tables are judged, because only a table's column can carry a masking
-// policy: the masker resolves a source column through SchemaMetadata.GetTable
-// (query_result_masker.go getColumn), and SchemaCatalog, where semantic types
-// live, holds tables alone. A view, materialized view or foreign table column
-// yields NoneMasker whatever the snapshot says, so refusing an empty one
-// withholds a result masking never changed and breaks two shapes PostgreSQL
-// accepts. Partitions resolve through GetTable to their parent.
+// relationHasNoSyncedColumns checks tables only: masking policies attach to
+// table columns, and GetTable resolves partitions to their parent.
+// A legal zero-column table is indistinguishable from degraded metadata and
+// remains blocked even after re-syncing.
 func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.ColumnResource) bool {
 	meta, err := e.getDatabaseMetadata(relation.Database)
 	if err != nil || meta == nil {
@@ -253,13 +227,6 @@ func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.Column
 }
 
 // getQuerySpan extracts the query span for the given SQL statement.
-//
-// The signal is set on the three return paths that carry result columns. The
-// other three return no table data for masking to protect: a non-SELECT
-// statement, EXPLAIN ANALYZE, whose rows are plan output rather than the
-// relation's, and SET or SHOW. Their empty Results slice is not the reason on
-// its own, since an empty Results slice on a SELECT is the state this signal
-// exists to catch.
 func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) (*base.QuerySpan, error) {
 	e.ctx = ctx
 

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -255,8 +255,11 @@ func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.Column
 // getQuerySpan extracts the query span for the given SQL statement.
 //
 // The signal is set on the three return paths that carry result columns. The
-// other three return an empty Results slice, and masking builds its maskers by
-// walking Results, so there is nothing there for the signal to protect.
+// other three return no table data for masking to protect: a non-SELECT
+// statement, EXPLAIN ANALYZE, whose rows are plan output rather than the
+// relation's, and SET or SHOW. Their empty Results slice is not the reason on
+// its own, since an empty Results slice on a SELECT is the state this signal
+// exists to catch.
 func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) (*base.QuerySpan, error) {
 	e.ctx = ctx
 

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -182,7 +182,81 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 	return "", 0, 0
 }
 
+// unresolvedColumnsError reports the relations in accesses that the stored
+// snapshot lists with no columns, or nil when every one resolves. It reads the
+// snapshot rather than analyzer
+// output, so the analyzed, expression-fallback and table-returning-function
+// paths all report the same condition.
+//
+// Every access is checked, including one naming a CTE that shares a listed
+// relation's name: ExtractAccessTables does not model CTE scope, so such a query
+// is refused rather than passed. Do not filter this set by CTE scope. A filter
+// can only drop a refusal, and a scope walk drops real reads — it misses an
+// aggregate's FILTER and ORDER BY subqueries and folds case on quoted CTE names,
+// each one a query returning unmasked rows.
+//
+// DEFER: a relation the access set never reports goes unchecked and stays
+// unmasked. A relation absent from the snapshot has no ceiling to raise here;
+// column resolution drops it upstream. The two reachable gaps are a
+// SQL-language function body (BYT-10075) and a FROM-clause function argument or
+// VALUES list (BYT-10076); upgrade when either ticket lands.
+//
+// #20581 (3.19.1) made the sync read columns from pg_catalog, so privileges no
+// longer produce this state; a snapshot written before that fix still carries it,
+// and the sync's read-committed transaction can still store a table created
+// between its column pass and its table pass with no columns.
+func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet) *base.UnresolvedColumnsError {
+	seen := make(map[base.ColumnResource]bool, len(accesses))
+	var unresolved []base.ColumnResource
+	for access := range accesses {
+		relation := base.ColumnResource{
+			Server:   access.Server,
+			Database: access.Database,
+			Schema:   access.Schema,
+			Table:    access.Table,
+		}
+		if relation.Table == "" || seen[relation] {
+			continue
+		}
+		seen[relation] = true
+		if e.relationHasNoSyncedColumns(relation) {
+			unresolved = append(unresolved, relation)
+		}
+	}
+	if len(unresolved) == 0 {
+		return nil
+	}
+	return &base.UnresolvedColumnsError{Relations: unresolved}
+}
+
+// relationHasNoSyncedColumns reports whether the snapshot carries the relation
+// as a table with an empty column list, and false for anything else.
+//
+// Only tables are judged, because only a table's column can carry a masking
+// policy: the masker resolves a source column through SchemaMetadata.GetTable
+// (query_result_masker.go getColumn), and SchemaCatalog, where semantic types
+// live, holds tables alone. A view, materialized view or foreign table column
+// yields NoneMasker whatever the snapshot says, so refusing an empty one
+// withholds a result masking never changed and breaks two shapes PostgreSQL
+// accepts. Partitions resolve through GetTable to their parent.
+func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.ColumnResource) bool {
+	meta, err := e.getDatabaseMetadata(relation.Database)
+	if err != nil || meta == nil {
+		return false
+	}
+	schema := meta.GetSchemaMetadata(relation.Schema)
+	if schema == nil {
+		return false
+	}
+	table := schema.GetTable(relation.Table)
+	return table != nil && len(table.GetProto().GetColumns()) == 0
+}
+
 // getQuerySpan extracts the query span for the given SQL statement.
+//
+// The signal is set on the three return paths that carry result columns. The
+// other three return an empty Results slice, and masking builds its maskers by
+// walking Results, so there is nothing there for the signal to protect.
 func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) (*base.QuerySpan, error) {
 	e.ctx = ctx
 
@@ -276,18 +350,20 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 		// used as table sources: SELECT * FROM func()).
 		if results := e.tryUserFuncTableSource(selStmt, accessesMap); results != nil {
 			return &base.QuerySpan{
-				Type:          base.Select,
-				SourceColumns: accessesMap,
-				Results:       results,
+				Type:                   base.Select,
+				SourceColumns:          accessesMap,
+				Results:                results,
+				UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
 			}, nil
 		}
 		// Fail-open: return access tables with best-effort column names and lineage
 		// when analysis fails (e.g., unsupported built-in functions).
 		return &base.QuerySpan{
-			Type:             base.Select,
-			SourceColumns:    accessesMap,
-			Results:          e.extractFallbackColumns(selStmt),
-			PredicateColumns: e.funcPredicateColumns,
+			Type:                   base.Select,
+			SourceColumns:          accessesMap,
+			Results:                e.extractFallbackColumns(selStmt),
+			PredicateColumns:       e.funcPredicateColumns,
+			UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
 		}, nil
 	}
 
@@ -302,10 +378,11 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 	}
 
 	return &base.QuerySpan{
-		Type:             base.Select,
-		SourceColumns:    accessesMap,
-		PredicateColumns: e.funcPredicateColumns,
-		Results:          results,
+		Type:                   base.Select,
+		SourceColumns:          accessesMap,
+		PredicateColumns:       e.funcPredicateColumns,
+		Results:                results,
+		UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
 	}, nil
 }
 

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -269,6 +269,47 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	})
 }
 
+// TestUnresolvedColumnsSignalResolvesRelationsNotRoutines pins that an
+// unqualified name resolves to a relation, not to whatever object comes first in
+// the search path.
+//
+// PostgreSQL keeps relations and routines in separate namespaces, so with
+// search_path "a, b", a function a.t and a table b.t, SELECT * FROM t reads b.t
+// (verified on PostgreSQL 17: 't'::regclass resolves to schema b while pg_proc
+// holds t in a). The access-table walker used SearchObject, which matches
+// functions, procedures and packages too, so it recorded a.t instead: the guard
+// then found no table in a and the query returned raw rows. It also pointed the
+// query access check at a schema the statement never reads.
+func TestUnresolvedColumnsSignalResolvesRelationsNotRoutines(t *testing.T) {
+	// A function in the earlier schema must not divert the read.
+	shadowed := &storepb.DatabaseSchemaMetadata{
+		Name:       "db",
+		SearchPath: "a, b",
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "a", Functions: []*storepb.FunctionMetadata{{Name: "t", Signature: "t()"}}},
+			{Name: "b", Tables: []*storepb.TableMetadata{{Name: "t"}}},
+		},
+	}
+	span := spanFor(t, "SELECT * FROM t", shadowed)
+	require.NotNil(t, span.UnresolvedColumnsError,
+		"a routine named like the table must not shadow it, or the column-less b.t goes unchecked")
+	require.Contains(t, span.UnresolvedColumnsError.Error(), "b.t")
+
+	// A relation in the earlier schema must still win: a sequence is a relation,
+	// and PostgreSQL resolves SELECT * FROM t to it (verified on 17, relkind S).
+	sequenceFirst := &storepb.DatabaseSchemaMetadata{
+		Name:       "db",
+		SearchPath: "a, b",
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "a", Sequences: []*storepb.SequenceMetadata{{Name: "t"}}},
+			{Name: "b", Tables: []*storepb.TableMetadata{{Name: "t"}}},
+		},
+	}
+	span = spanFor(t, "SELECT * FROM t", sequenceFirst)
+	require.Nil(t, span.UnresolvedColumnsError,
+		"the sequence in a is the relation this query reads, and a sequence carries no column list to judge")
+}
+
 // TestUnresolvedColumnsSignalNotCoveredShapes pins the reads this signal cannot
 // see, so the boundary is a recorded decision rather than something a reviewer
 // rediscovers.

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -14,8 +14,6 @@ func column(name, typ string) *storepb.ColumnMetadata {
 	return &storepb.ColumnMetadata{Name: name, Type: typ}
 }
 
-// healthySchema mirrors a fully synced database: two tables with columns, a
-// view, and a materialized view with the dependency columns real sync records.
 func healthySchema() *storepb.DatabaseSchemaMetadata {
 	return &storepb.DatabaseSchemaMetadata{
 		Name: "db",
@@ -42,16 +40,11 @@ func healthySchema() *storepb.DatabaseSchemaMetadata {
 	}
 }
 
-// degradedSchema is what a pre-#20581 sync left behind when the connecting role
-// lost its privileges: the table is still listed, with no columns under it. A
-// current PostgreSQL sync reads pg_catalog and cannot produce this, but a
-// snapshot written by an older version and never re-synced still carries it.
+// A table with no columns models a snapshot from a sync before #20581.
 func degradedSchema() *storepb.DatabaseSchemaMetadata {
 	return degradedSchemaNamed("t")
 }
 
-// degradedSchemaNamed is degradedSchema with the column-less table under a
-// chosen name, for statements that also bind a CTE of that name.
 func degradedSchemaNamed(table string) *storepb.DatabaseSchemaMetadata {
 	return &storepb.DatabaseSchemaMetadata{
 		Name: "db",
@@ -62,10 +55,6 @@ func degradedSchemaNamed(table string) *storepb.DatabaseSchemaMetadata {
 	}
 }
 
-// degradedViewSchema is the same degradation reaching a view. The syncer fills a
-// view's column list from the same map as a table's, so a pre-#20581 snapshot
-// empties both. Masking cannot read a view's columns either way, so this fixture
-// pins that a view is not refused.
 func degradedViewSchema() *storepb.DatabaseSchemaMetadata {
 	return &storepb.DatabaseSchemaMetadata{
 		Name: "db",
@@ -77,8 +66,6 @@ func degradedViewSchema() *storepb.DatabaseSchemaMetadata {
 	}
 }
 
-// partialSchema keeps some of the table's columns. Same-arity drift like this is
-// out of scope for the unresolved-columns signal; see the masking follow-up.
 func partialSchema() *storepb.DatabaseSchemaMetadata {
 	return &storepb.DatabaseSchemaMetadata{
 		Name: "db",
@@ -101,26 +88,15 @@ func spanFor(t *testing.T, statement string, metadata *storepb.DatabaseSchemaMet
 	return span
 }
 
-// TestUnresolvedColumnsSignalFiresOnDegradedSnapshot covers the reported bug: a
-// table synced with no columns yields a span whose lineage cannot support
-// masking. Every one of these shapes returned unmasked rows before the signal
-// existed, and none of them sets NotFoundError, so nothing else marks them.
 func TestUnresolvedColumnsSignalFiresOnDegradedSnapshot(t *testing.T) {
 	statements := []string{
 		"SELECT * FROM public.t",
-		// The analyzer rejects the four shapes below — the degraded table has no
-		// column to bind email, id or ssn to — so they exercise the fallback path,
-		// which has no scope resolution to consult and checks every access.
 		"SELECT email FROM public.t",
 		"SELECT t.email FROM public.t",
 		"SELECT * FROM public.t WHERE email = 'x'",
 		"SELECT id, email FROM public.t ORDER BY ssn",
 		"WITH c AS (SELECT * FROM public.t) SELECT * FROM c",
-		// The unqualified t inside a non-recursive CTE body is the physical
-		// table: a CTE's own name is not visible in its body. These three sat
-		// in positions an analyzed-query walk did not reach (an aggregate's
-		// FILTER and ORDER BY subqueries) or folded case on a quoted CTE name,
-		// and an earlier revision let them run unmasked.
+		// A non-recursive CTE cannot reference itself; the inner t is the physical table.
 		"WITH t AS (SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM t)) AS c FROM (SELECT 1) x) SELECT * FROM t",
 		"WITH t AS (SELECT string_agg('x', ',' ORDER BY (SELECT count(*) FROM t)) AS c FROM (SELECT 1) x) SELECT * FROM t",
 		`WITH "T" AS (SELECT 1 AS n) SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM t)) FROM "T"`,
@@ -139,25 +115,11 @@ func TestUnresolvedColumnsSignalFiresOnDegradedSnapshot(t *testing.T) {
 	}
 }
 
-// TestUnresolvedColumnsSignalQuietOnHealthySnapshot is the false-positive guard.
-// Enforcement refuses the query, so every shape here would become a broken query.
-//
-// The joins and the expression-fallback case are the load-bearing ones: they
-// report relations, so a wrong predicate would refuse them. The EXPLAIN, SHOW,
-// SET and constant-select cases report no relation at all and cannot fire
-// whatever the predicate does; they are here as regression guards on that, not
-// as evidence the predicate is right. They defeated an earlier arity-based
-// version of this check, which is a different mechanism.
-//
-// Quiet here means "the snapshot describes every relation", not "masking is
-// correct". NATURAL JOIN in particular produces one span result per input
-// column (5 for t(id,email,ssn) NATURAL JOIN o(id,amt)) while the driver
-// returns the 4 merged ones, and doMaskResult is positional, so its maskers
-// land one column off. That is a separate defect on the snapshot's healthy path.
 func TestUnresolvedColumnsSignalQuietOnHealthySnapshot(t *testing.T) {
 	statements := []string{
 		"SELECT * FROM public.t",
 		"SELECT email FROM public.t",
+		// Signal absence checks snapshot completeness, not masking correctness.
 		"SELECT * FROM public.t NATURAL JOIN public.o",
 		"SELECT * FROM public.t JOIN public.o USING (id)",
 		"SELECT * FROM public.t LEFT JOIN public.o ON t.id = o.id",
@@ -185,8 +147,6 @@ func TestUnresolvedColumnsSignalQuietOnHealthySnapshot(t *testing.T) {
 	}
 }
 
-// TestUnresolvedColumnsSignalScope pins what this signal deliberately does not
-// cover, so a later change does not silently widen or narrow it.
 func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	t.Run("partial column loss is out of scope", func(t *testing.T) {
 		span := spanFor(t, "SELECT * FROM public.t", partialSchema())
@@ -195,7 +155,6 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	})
 
 	t.Run("a view with no synced columns is not refused", func(t *testing.T) {
-		// Why only tables are judged is at relationHasNoSyncedColumns.
 		span := spanFor(t, "SELECT * FROM public.v", degradedViewSchema())
 		require.Nil(t, span.UnresolvedColumnsError)
 	})
@@ -213,12 +172,6 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	})
 
 	t.Run("a CTE named like a degraded relation is refused too", func(t *testing.T) {
-		// ExtractAccessTables resolves the unqualified t to public.t without
-		// modeling CTE scope, so the access set names a table this query never
-		// reads. That is accepted: resolving CTE scope needs a second walk over
-		// the analyzed query, and an earlier revision's walk let real reads
-		// through (see the FILTER and ORDER BY cases in the fires test). On a
-		// snapshot a re-sync repairs, the refusal lasts one query.
 		for _, statement := range []string{
 			"WITH t AS (SELECT 1 AS n) SELECT * FROM t",
 			"WITH outer_q AS (WITH t AS (SELECT 1 AS n) SELECT * FROM t) SELECT * FROM outer_q",
@@ -231,30 +184,23 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	})
 
 	t.Run("a non-recursive CTE reading its own name reads the table", func(t *testing.T) {
-		// A non-recursive CTE's own name is not visible inside its own body, so
-		// the inner t is the physical public.t (verified on PostgreSQL 17).
 		span := spanFor(t, "WITH t AS (SELECT * FROM t) SELECT * FROM t", degradedSchema())
 		require.NotNil(t, span.UnresolvedColumnsError)
 		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
 	})
 
 	t.Run("a qualified read is still checked when a CTE shares the name", func(t *testing.T) {
-		// PostgreSQL does not let a CTE shadow a schema-qualified name.
 		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM public.t", degradedSchema())
 		require.NotNil(t, span.UnresolvedColumnsError)
 		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
 	})
 
 	t.Run("a statement reading both the CTE and the qualified table is checked", func(t *testing.T) {
-		// The arms project different column counts, so the analyzer rejects the
-		// statement and the fallback path carries it.
 		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM t UNION ALL SELECT * FROM public.t", degradedSchema())
 		require.NotNil(t, span.UnresolvedColumnsError)
 	})
 
 	t.Run("materialized view without columns is not a degraded table", func(t *testing.T) {
-		// MaterializedViewMetadata has no column list by design, so an empty one
-		// says nothing about snapshot health.
 		span := spanFor(t, "SELECT * FROM public.mv", healthySchema())
 		require.Nil(t, span.UnresolvedColumnsError)
 	})
@@ -269,19 +215,8 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	})
 }
 
-// TestUnresolvedColumnsSignalResolvesRelationsNotRoutines pins that an
-// unqualified name resolves to a relation, not to whatever object comes first in
-// the search path.
-//
-// PostgreSQL keeps relations and routines in separate namespaces, so with
-// search_path "a, b", a function a.t and a table b.t, SELECT * FROM t reads b.t
-// (verified on PostgreSQL 17: 't'::regclass resolves to schema b while pg_proc
-// holds t in a). The access-table walker used SearchObject, which matches
-// functions, procedures and packages too, so it recorded a.t instead: the guard
-// then found no table in a and the query returned raw rows. It also pointed the
-// query access check at a schema the statement never reads.
 func TestUnresolvedColumnsSignalResolvesRelationsNotRoutines(t *testing.T) {
-	// A function in the earlier schema must not divert the read.
+	// Routines do not shadow relations in PostgreSQL search_path resolution.
 	shadowed := &storepb.DatabaseSchemaMetadata{
 		Name:       "db",
 		SearchPath: "a, b",
@@ -295,8 +230,7 @@ func TestUnresolvedColumnsSignalResolvesRelationsNotRoutines(t *testing.T) {
 		"a routine named like the table must not shadow it, or the column-less b.t goes unchecked")
 	require.Contains(t, span.UnresolvedColumnsError.Error(), "b.t")
 
-	// A relation in the earlier schema must still win: a sequence is a relation,
-	// and PostgreSQL resolves SELECT * FROM t to it (verified on 17, relkind S).
+	// Sequences share the relation namespace and do shadow later tables.
 	sequenceFirst := &storepb.DatabaseSchemaMetadata{
 		Name:       "db",
 		SearchPath: "a, b",
@@ -310,14 +244,7 @@ func TestUnresolvedColumnsSignalResolvesRelationsNotRoutines(t *testing.T) {
 		"the sequence in a is the relation this query reads, and a sequence carries no column list to judge")
 }
 
-// TestUnresolvedColumnsSignalNotCoveredShapes pins the reads this signal cannot
-// see, so the boundary is a recorded decision rather than something a reviewer
-// rediscovers.
-//
-// These are not walk gaps. ExtractAccessTables never reports the relation at
-// all, so it is absent from span.SourceColumns too — the access-level fix
-// belongs upstream and is tracked in BYT-10076. Until then a query shaped like
-// this returns unmasked rows against a degraded snapshot.
+// BYT-10076 tracks reads omitted from the access set; these cases record that gap.
 func TestUnresolvedColumnsSignalNotCoveredShapes(t *testing.T) {
 	notCovered := map[string]string{
 		"subquery in a FROM-clause function argument": "SELECT * FROM generate_series(1, (SELECT count(*)::int FROM public.d))",

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -1,0 +1,294 @@
+package pg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func column(name, typ string) *storepb.ColumnMetadata {
+	return &storepb.ColumnMetadata{Name: name, Type: typ}
+}
+
+// healthySchema mirrors a fully synced database: two tables with columns, a
+// view, and a materialized view with the dependency columns real sync records.
+func healthySchema() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{
+				{Name: "t", Columns: []*storepb.ColumnMetadata{column("id", "int4"), column("email", "text"), column("ssn", "text")}},
+				{Name: "o", Columns: []*storepb.ColumnMetadata{column("id", "int4"), column("amt", "numeric")}},
+			},
+			Views: []*storepb.ViewMetadata{{
+				Name:       "v",
+				Definition: "SELECT id, email FROM public.t",
+				Columns:    []*storepb.ColumnMetadata{column("id", "int4"), column("email", "text")},
+			}},
+			MaterializedViews: []*storepb.MaterializedViewMetadata{{
+				Name:       "mv",
+				Definition: "SELECT id, ssn FROM public.t",
+				DependencyColumns: []*storepb.DependencyColumn{
+					{Schema: "public", Table: "t", Column: "id"},
+					{Schema: "public", Table: "t", Column: "ssn"},
+				},
+			}},
+		}},
+	}
+}
+
+// degradedSchema is what a pre-#20581 sync left behind when the connecting role
+// lost its privileges: the table is still listed, with no columns under it. A
+// current PostgreSQL sync reads pg_catalog and cannot produce this, but a
+// snapshot written by an older version and never re-synced still carries it.
+func degradedSchema() *storepb.DatabaseSchemaMetadata {
+	return degradedSchemaNamed("t")
+}
+
+// degradedSchemaNamed is degradedSchema with the column-less table under a
+// chosen name, for statements that also bind a CTE of that name.
+func degradedSchemaNamed(table string) *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name:   "public",
+			Tables: []*storepb.TableMetadata{{Name: table}},
+		}},
+	}
+}
+
+// degradedViewSchema is the same degradation reaching a view. The syncer fills a
+// view's column list from the same map as a table's, so a pre-#20581 snapshot
+// empties both. Masking cannot read a view's columns either way, so this fixture
+// pins that a view is not refused.
+func degradedViewSchema() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name:   "public",
+			Tables: []*storepb.TableMetadata{{Name: "t"}},
+			Views:  []*storepb.ViewMetadata{{Name: "v", Definition: "SELECT id, email FROM public.t"}},
+		}},
+	}
+}
+
+// partialSchema keeps some of the table's columns. Same-arity drift like this is
+// out of scope for the unresolved-columns signal; see the masking follow-up.
+func partialSchema() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name:   "public",
+			Tables: []*storepb.TableMetadata{{Name: "t", Columns: []*storepb.ColumnMetadata{column("email", "text"), column("ssn", "text")}}},
+		}},
+	}
+}
+
+func spanFor(t *testing.T, statement string, metadata *storepb.DatabaseSchemaMetadata) *base.QuerySpan {
+	t.Helper()
+	getter, lister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+	span, err := GetQuerySpan(context.Background(), base.GetQuerySpanContext{
+		InstanceID:              "inst",
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+	}, base.Statement{Text: statement}, metadata.Name, "", false)
+	require.NoError(t, err)
+	return span
+}
+
+// TestUnresolvedColumnsSignalFiresOnDegradedSnapshot covers the reported bug: a
+// table synced with no columns yields a span whose lineage cannot support
+// masking. Every one of these shapes returned unmasked rows before the signal
+// existed, and none of them sets NotFoundError, so nothing else marks them.
+func TestUnresolvedColumnsSignalFiresOnDegradedSnapshot(t *testing.T) {
+	statements := []string{
+		"SELECT * FROM public.t",
+		// The analyzer rejects the four shapes below — the degraded table has no
+		// column to bind email, id or ssn to — so they exercise the fallback path,
+		// which has no scope resolution to consult and checks every access.
+		"SELECT email FROM public.t",
+		"SELECT t.email FROM public.t",
+		"SELECT * FROM public.t WHERE email = 'x'",
+		"SELECT id, email FROM public.t ORDER BY ssn",
+		"WITH c AS (SELECT * FROM public.t) SELECT * FROM c",
+		// The unqualified t inside a non-recursive CTE body is the physical
+		// table: a CTE's own name is not visible in its body. These three sat
+		// in positions an analyzed-query walk did not reach (an aggregate's
+		// FILTER and ORDER BY subqueries) or folded case on a quoted CTE name,
+		// and an earlier revision let them run unmasked.
+		"WITH t AS (SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM t)) AS c FROM (SELECT 1) x) SELECT * FROM t",
+		"WITH t AS (SELECT string_agg('x', ',' ORDER BY (SELECT count(*) FROM t)) AS c FROM (SELECT 1) x) SELECT * FROM t",
+		`WITH "T" AS (SELECT 1 AS n) SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM t)) FROM "T"`,
+	}
+	for _, statement := range statements {
+		t.Run(statement, func(t *testing.T) {
+			span := spanFor(t, statement, degradedSchema())
+			require.NotNil(t, span.UnresolvedColumnsError,
+				"a table with no synced columns must mark the span as unresolvable")
+			require.Nil(t, span.NotFoundError,
+				"this signal exists because NotFoundError does not fire here; if it starts to, one rule is enforced at two points")
+			require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+			require.Equal(t, []string{"db"}, span.UnresolvedColumnsError.Databases(),
+				"the re-sync must target the database holding the unresolved relation")
+		})
+	}
+}
+
+// TestUnresolvedColumnsSignalQuietOnHealthySnapshot is the false-positive guard.
+// Enforcement refuses the query, so every shape here would become a broken query.
+//
+// The joins and the expression-fallback case are the load-bearing ones: they
+// report relations, so a wrong predicate would refuse them. The EXPLAIN, SHOW,
+// SET and constant-select cases report no relation at all and cannot fire
+// whatever the predicate does; they are here as regression guards on that, not
+// as evidence the predicate is right. They defeated an earlier arity-based
+// version of this check, which is a different mechanism.
+//
+// Quiet here means "the snapshot describes every relation", not "masking is
+// correct". NATURAL JOIN in particular produces one span result per input
+// column (5 for t(id,email,ssn) NATURAL JOIN o(id,amt)) while the driver
+// returns the 4 merged ones, and doMaskResult is positional, so its maskers
+// land one column off. That is a separate defect on the snapshot's healthy path.
+func TestUnresolvedColumnsSignalQuietOnHealthySnapshot(t *testing.T) {
+	statements := []string{
+		"SELECT * FROM public.t",
+		"SELECT email FROM public.t",
+		"SELECT * FROM public.t NATURAL JOIN public.o",
+		"SELECT * FROM public.t JOIN public.o USING (id)",
+		"SELECT * FROM public.t LEFT JOIN public.o ON t.id = o.id",
+		"SELECT *, md5(email) FROM public.t",
+		"SELECT * FROM public.v",
+		"SELECT * FROM public.mv",
+		"WITH c AS (SELECT * FROM public.t) SELECT * FROM c",
+		"SELECT * FROM public.t UNION ALL SELECT * FROM public.t",
+		"SELECT DISTINCT ON (id) * FROM public.t",
+		"SELECT count(*) FROM public.t",
+		"SELECT 1",
+		"SELECT * FROM generate_series(1, 3)",
+		"EXPLAIN SELECT * FROM public.t",
+		"EXPLAIN ANALYZE SELECT * FROM public.t",
+		"-- plan\nEXPLAIN ANALYZE SELECT * FROM public.t",
+		"SHOW search_path",
+		"SET search_path TO public",
+	}
+	for _, statement := range statements {
+		t.Run(statement, func(t *testing.T) {
+			span := spanFor(t, statement, healthySchema())
+			require.Nil(t, span.UnresolvedColumnsError,
+				"a fully synced snapshot must never mark a span unresolvable")
+		})
+	}
+}
+
+// TestUnresolvedColumnsSignalScope pins what this signal deliberately does not
+// cover, so a later change does not silently widen or narrow it.
+func TestUnresolvedColumnsSignalScope(t *testing.T) {
+	t.Run("partial column loss is out of scope", func(t *testing.T) {
+		span := spanFor(t, "SELECT * FROM public.t", partialSchema())
+		require.Nil(t, span.UnresolvedColumnsError,
+			"a table with some columns resolves; same-arity drift needs the catalog-comparison follow-up")
+	})
+
+	t.Run("a view with no synced columns is not refused", func(t *testing.T) {
+		// Why only tables are judged is at relationHasNoSyncedColumns.
+		span := spanFor(t, "SELECT * FROM public.v", degradedViewSchema())
+		require.Nil(t, span.UnresolvedColumnsError)
+	})
+
+	t.Run("a foreign table with no synced columns is not refused", func(t *testing.T) {
+		metadata := &storepb.DatabaseSchemaMetadata{
+			Name: "db",
+			Schemas: []*storepb.SchemaMetadata{{
+				Name:           "public",
+				ExternalTables: []*storepb.ExternalTableMetadata{{Name: "ft"}},
+			}},
+		}
+		span := spanFor(t, "SELECT * FROM public.ft", metadata)
+		require.Nil(t, span.UnresolvedColumnsError)
+	})
+
+	t.Run("a CTE named like a degraded relation is refused too", func(t *testing.T) {
+		// ExtractAccessTables resolves the unqualified t to public.t without
+		// modeling CTE scope, so the access set names a table this query never
+		// reads. That is accepted: resolving CTE scope needs a second walk over
+		// the analyzed query, and an earlier revision's walk let real reads
+		// through (see the FILTER and ORDER BY cases in the fires test). On a
+		// snapshot a re-sync repairs, the refusal lasts one query.
+		for _, statement := range []string{
+			"WITH t AS (SELECT 1 AS n) SELECT * FROM t",
+			"WITH outer_q AS (WITH t AS (SELECT 1 AS n) SELECT * FROM t) SELECT * FROM outer_q",
+			"SELECT * FROM (WITH t AS (SELECT 1 AS n) SELECT * FROM t) q",
+			"WITH RECURSIVE t AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM t WHERE n < 3) SELECT * FROM t",
+		} {
+			span := spanFor(t, statement, degradedSchema())
+			require.NotNil(t, span.UnresolvedColumnsError, statement)
+		}
+	})
+
+	t.Run("a non-recursive CTE reading its own name reads the table", func(t *testing.T) {
+		// A non-recursive CTE's own name is not visible inside its own body, so
+		// the inner t is the physical public.t (verified on PostgreSQL 17).
+		span := spanFor(t, "WITH t AS (SELECT * FROM t) SELECT * FROM t", degradedSchema())
+		require.NotNil(t, span.UnresolvedColumnsError)
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+	})
+
+	t.Run("a qualified read is still checked when a CTE shares the name", func(t *testing.T) {
+		// PostgreSQL does not let a CTE shadow a schema-qualified name.
+		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM public.t", degradedSchema())
+		require.NotNil(t, span.UnresolvedColumnsError)
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+	})
+
+	t.Run("a statement reading both the CTE and the qualified table is checked", func(t *testing.T) {
+		// The arms project different column counts, so the analyzer rejects the
+		// statement and the fallback path carries it.
+		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM t UNION ALL SELECT * FROM public.t", degradedSchema())
+		require.NotNil(t, span.UnresolvedColumnsError)
+	})
+
+	t.Run("materialized view without columns is not a degraded table", func(t *testing.T) {
+		// MaterializedViewMetadata has no column list by design, so an empty one
+		// says nothing about snapshot health.
+		span := spanFor(t, "SELECT * FROM public.mv", healthySchema())
+		require.Nil(t, span.UnresolvedColumnsError)
+	})
+
+	t.Run("error names every unresolved relation", func(t *testing.T) {
+		metadata := degradedSchema()
+		metadata.Schemas[0].Tables = append(metadata.Schemas[0].Tables, &storepb.TableMetadata{Name: "o"})
+		span := spanFor(t, "SELECT * FROM public.t, public.o", metadata)
+		require.NotNil(t, span.UnresolvedColumnsError)
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.o")
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+	})
+}
+
+// TestUnresolvedColumnsSignalNotCoveredShapes pins the reads this signal cannot
+// see, so the boundary is a recorded decision rather than something a reviewer
+// rediscovers.
+//
+// These are not walk gaps. ExtractAccessTables never reports the relation at
+// all, so it is absent from span.SourceColumns too — the access-level fix
+// belongs upstream and is tracked in BYT-10076. Until then a query shaped like
+// this returns unmasked rows against a degraded snapshot.
+func TestUnresolvedColumnsSignalNotCoveredShapes(t *testing.T) {
+	notCovered := map[string]string{
+		"subquery in a FROM-clause function argument": "SELECT * FROM generate_series(1, (SELECT count(*)::int FROM public.d))",
+		"subquery inside a VALUES list":               "SELECT * FROM (VALUES ((SELECT count(*) FROM public.d))) v(x)",
+	}
+	for name, statement := range notCovered {
+		t.Run(name, func(t *testing.T) {
+			span := spanFor(t, statement, degradedSchemaNamed("d"))
+			require.Empty(t, span.SourceColumns,
+				"the premise of this gap is that the access set is empty; if this fails the gap may have been closed upstream")
+			require.Nil(t, span.UnresolvedColumnsError,
+				"documented gap: no access reported, so nothing to check (BYT-10076)")
+		})
+	}
+}

--- a/backend/plugin/parser/redshift/query_span_extractor_omni.go
+++ b/backend/plugin/parser/redshift/query_span_extractor_omni.go
@@ -280,7 +280,7 @@ func (r *redshiftQuerySpanRelationResolver) ResolveRelation(schemaName, relation
 
 	resolvedSchemaName, resolvedRelationName := schemaName, relationName
 	if resolvedSchemaName == "" {
-		resolvedSchemaName, resolvedRelationName = r.metadata.SearchObject(searchPath, relationName)
+		resolvedSchemaName, resolvedRelationName = r.metadata.SearchRelation(searchPath, relationName)
 		if resolvedSchemaName == "" && resolvedRelationName == "" {
 			return nil, nil
 		}
@@ -439,7 +439,7 @@ func collectRedshiftSchemaQualificationEdits(metadata *model.DatabaseMetadata, s
 		if isOmniCTEReference(rangeVar, ctes) || rangeVar.Loc.Start < 0 {
 			return true
 		}
-		schemaName, _ := metadata.SearchObject(searchPath, rangeVar.Relname)
+		schemaName, _ := metadata.SearchRelation(searchPath, rangeVar.Relname)
 		if schemaName == "" {
 			return true
 		}
@@ -1274,18 +1274,20 @@ func (q *omniQuerySpanExtractor) omniAccessTableExists(ctx context.Context, reso
 		return false
 	}
 	if resource.Schema == "" {
-		schemaName, objectName := metadata.SearchObject(q.searchPath, resource.Table)
+		schemaName, objectName := metadata.SearchRelation(q.searchPath, resource.Table)
 		return schemaName != "" || objectName != ""
 	}
 	schema := metadata.GetSchemaMetadata(resource.Schema)
 	if schema == nil {
 		return false
 	}
+	// Relation kinds only, matching SearchRelation on the unqualified branch
+	// above: an access table comes from a RangeVar, and PostgreSQL resolves those
+	// against the relation namespace.
 	return schema.GetTable(resource.Table) != nil ||
 		schema.GetView(resource.Table) != nil ||
 		schema.GetMaterializedView(resource.Table) != nil ||
 		schema.GetExternalTable(resource.Table) != nil ||
-		schema.GetFunction(resource.Table) != nil ||
 		schema.GetSequence(resource.Table) != nil
 }
 
@@ -1309,7 +1311,7 @@ func (q *omniQuerySpanExtractor) resolveOmniRangeVar(ctx context.Context, rangeV
 	if metadata == nil {
 		return resource, nil
 	}
-	schemaName, objectName := metadata.SearchObject(q.searchPath, resource.Table)
+	schemaName, objectName := metadata.SearchRelation(q.searchPath, resource.Table)
 	if schemaName == "" && objectName == "" {
 		return base.ColumnResource{}, &base.ResourceNotFoundError{
 			Database: &resource.Database,

--- a/backend/plugin/parser/redshift/query_span_extractor_omni.go
+++ b/backend/plugin/parser/redshift/query_span_extractor_omni.go
@@ -1281,9 +1281,7 @@ func (q *omniQuerySpanExtractor) omniAccessTableExists(ctx context.Context, reso
 	if schema == nil {
 		return false
 	}
-	// Relation kinds only, matching SearchRelation on the unqualified branch
-	// above: an access table comes from a RangeVar, and PostgreSQL resolves those
-	// against the relation namespace.
+	// Match the relation kinds used by SearchRelation above.
 	return schema.GetTable(resource.Table) != nil ||
 		schema.GetView(resource.Table) != nil ||
 		schema.GetMaterializedView(resource.Table) != nil ||

--- a/backend/store/model/pg_searcher.go
+++ b/backend/store/model/pg_searcher.go
@@ -156,21 +156,6 @@ func (s *DatabaseSearcher) SearchFunctions(name string) ([]string, []*storepb.Fu
 	return schemas, funcs
 }
 
-// SearchObject searches for any database object in the search path.
-// NOTE: This is primarily designed for PostgreSQL's search_path concept.
-func (s *DatabaseSearcher) SearchObject(name string) (string, string) {
-	for _, schemaName := range s.searchPath {
-		schema := s.db.GetSchemaMetadata(schemaName)
-		if schema == nil {
-			continue
-		}
-		if schema.GetTable(name) != nil || schema.GetView(name) != nil || schema.GetMaterializedView(name) != nil || schema.GetFunction(name) != nil || schema.GetProcedure(name) != nil || schema.GetPackage(name) != nil || schema.GetSequence(name) != nil || schema.GetExternalTable(name) != nil {
-			return schema.proto.Name, name
-		}
-	}
-	return "", ""
-}
-
 // SearchTable searches for a table in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
 func (d *DatabaseMetadata) SearchTable(searchPath []string, name string) (string, *TableMetadata) {
@@ -300,9 +285,9 @@ func (d *DatabaseMetadata) SearchFunctions(searchPath []string, name string) ([]
 // PostgreSQL keeps relations and routines in separate namespaces, so a function,
 // procedure or package named like a table does not shadow it: SELECT * FROM t
 // reads the table wherever it sits in the path, even if an earlier schema has a
-// function t. SearchObject matches routines as well and is for callers resolving
-// a name that could be either; a caller resolving a FROM-clause reference wants
-// this one, or it records an access on a schema the query never reads.
+// function t. Resolving one with a search that also matches routines records an
+// access on a schema the query never reads, which both hides a degraded relation
+// from masking and points the query access check at the wrong schema.
 func (d *DatabaseMetadata) SearchRelation(searchPath []string, name string) (string, string) {
 	for _, schemaName := range searchPath {
 		schema := d.GetSchemaMetadata(schemaName)
@@ -310,23 +295,6 @@ func (d *DatabaseMetadata) SearchRelation(searchPath []string, name string) (str
 			continue
 		}
 		if schema.GetTable(name) != nil || schema.GetView(name) != nil || schema.GetMaterializedView(name) != nil || schema.GetExternalTable(name) != nil || schema.GetSequence(name) != nil {
-			return schema.proto.Name, name
-		}
-	}
-	return "", ""
-}
-
-// SearchObject searches for any database object in the search path.
-// NOTE: This is primarily designed for PostgreSQL's search_path concept.
-// It matches routines too, so a caller resolving a FROM-clause relation wants
-// SearchRelation instead.
-func (d *DatabaseMetadata) SearchObject(searchPath []string, name string) (string, string) {
-	for _, schemaName := range searchPath {
-		schema := d.GetSchemaMetadata(schemaName)
-		if schema == nil {
-			continue
-		}
-		if schema.GetTable(name) != nil || schema.GetView(name) != nil || schema.GetMaterializedView(name) != nil || schema.GetFunction(name) != nil || schema.GetProcedure(name) != nil || schema.GetPackage(name) != nil || schema.GetSequence(name) != nil || schema.GetExternalTable(name) != nil {
 			return schema.proto.Name, name
 		}
 	}

--- a/backend/store/model/pg_searcher.go
+++ b/backend/store/model/pg_searcher.go
@@ -279,15 +279,9 @@ func (d *DatabaseMetadata) SearchFunctions(searchPath []string, name string) ([]
 	return schemas, funcs
 }
 
-// SearchRelation resolves an unqualified name to the first schema in the search
-// path holding a relation of that name.
-//
-// PostgreSQL keeps relations and routines in separate namespaces, so a function,
-// procedure or package named like a table does not shadow it: SELECT * FROM t
-// reads the table wherever it sits in the path, even if an earlier schema has a
-// function t. Resolving one with a search that also matches routines records an
-// access on a schema the query never reads, which both hides a degraded relation
-// from masking and points the query access check at the wrong schema.
+// SearchRelation resolves a name to the first relation in the search path.
+// Routines do not shadow relations; sequences do, because PostgreSQL keeps
+// them in the relation namespace.
 func (d *DatabaseMetadata) SearchRelation(searchPath []string, name string) (string, string) {
 	for _, schemaName := range searchPath {
 		schema := d.GetSchemaMetadata(schemaName)

--- a/backend/store/model/pg_searcher.go
+++ b/backend/store/model/pg_searcher.go
@@ -294,8 +294,32 @@ func (d *DatabaseMetadata) SearchFunctions(searchPath []string, name string) ([]
 	return schemas, funcs
 }
 
+// SearchRelation resolves an unqualified name to the first schema in the search
+// path holding a relation of that name.
+//
+// PostgreSQL keeps relations and routines in separate namespaces, so a function,
+// procedure or package named like a table does not shadow it: SELECT * FROM t
+// reads the table wherever it sits in the path, even if an earlier schema has a
+// function t. SearchObject matches routines as well and is for callers resolving
+// a name that could be either; a caller resolving a FROM-clause reference wants
+// this one, or it records an access on a schema the query never reads.
+func (d *DatabaseMetadata) SearchRelation(searchPath []string, name string) (string, string) {
+	for _, schemaName := range searchPath {
+		schema := d.GetSchemaMetadata(schemaName)
+		if schema == nil {
+			continue
+		}
+		if schema.GetTable(name) != nil || schema.GetView(name) != nil || schema.GetMaterializedView(name) != nil || schema.GetExternalTable(name) != nil || schema.GetSequence(name) != nil {
+			return schema.proto.Name, name
+		}
+	}
+	return "", ""
+}
+
 // SearchObject searches for any database object in the search path.
 // NOTE: This is primarily designed for PostgreSQL's search_path concept.
+// It matches routines too, so a caller resolving a FROM-clause relation wants
+// SearchRelation instead.
 func (d *DatabaseMetadata) SearchObject(searchPath []string, name string) (string, string) {
 	for _, schemaName := range searchPath {
 		schema := d.GetSchemaMetadata(schemaName)


### PR DESCRIPTION
Closes the masking fail-open WealthNavi reported in BYT-10073.

Replaces #21197. That PR sat in draft while a CTE-scope walker was built to answer one review comment, and then had to be removed. This one is the shape that survived, at 194 production lines instead of 615.

## The problem

Bytebase masks query results column by column, from the stored schema snapshot. A sync that ran while the connecting role lacked privileges leaves a relation listed with **no columns under it**. Masking finds no columns, reads that as "nothing to mask", and returns **raw rows**, with no error, no log and no masking indicator.

`SELECT *` is both the common case and the worst one: the span produces no results, so `doMaskResult` applies no maskers at all. Export uses the same masker, so downloaded files carry raw data too.

The customer changed the role of their Bytebase database user, saw "No Data" for a schema's columns, and got the whole schema back unmasked. Pressing **Sync Database** restored masking with no reconfiguration. Their semantic types were never lost, only unreachable.

## The fix

`QuerySpan` gains `UnresolvedColumnsError`. The PostgreSQL extractor sets it when a relation the query reads is listed in the snapshot with no columns. It reads the snapshot directly rather than analyzer output, so all three lineage paths (analyzed, expression fallback, table-returning function) report the same condition.

Two consumers act on it, through one predicate:

1. `queryRetry` re-syncs the databases the signal names and rebuilds the span. A stale snapshot repairs itself here.
2. `MaskResults` refuses the query if a fresh sync still cannot describe the relation.

Re-sync targets come from the signal rather than from `SourceColumns`: `SourceColumns` names every database the query reads, and only the degraded ones need the sync.

**Only tables are judged.** A view, materialized view or foreign table column can never carry a masking policy: the masker resolves a source column through `SchemaMetadata.GetTable` (`query_result_masker.go` `getColumn`), and `SchemaCatalog`, where semantic types live, holds tables and nothing else. Refusing a column-less one would withhold a result masking never changed, and would break `CREATE VIEW v AS SELECT FROM t` and `CREATE FOREIGN TABLE ft() SERVER s`, both legal PostgreSQL. Partitions resolve through `GetTable` to their parent and inherit its verdict.

## A second fix on the same path

The PR also clears `DetailedError` when it redacts a query error, and that is a separate leak from the one above. `MaskResults` already replaced `Error` with a fixed string when the statement touches masked columns, because PostgreSQL quotes column values in messages like `invalid input syntax for type integer: "111-22-3333"`. It left the structured error alone. `getPgError` fills seventeen fields there, including `InternalQuery`, which carries the failing SQL text, plus `SchemaName`, `TableName` and `ColumnName`, and all of them reach the client verbatim. Redacting one channel and leaving the other redacted nothing.

This changes what clients receive on the query-error path, on healthy snapshots too, so it is worth reading as its own change rather than as part of the signal. It is also untested, for the same reason the refusal is: nothing reaches `MaskResults`.

## An unqualified name now resolves to a relation, not to any object

The access-table walker resolved a bare name with `SearchObject`, which matches functions, procedures, packages and sequences as well as relations. PostgreSQL keeps relations and routines in separate namespaces, so that is the wrong search: with `search_path` `a, b`, a function `a.t` and a table `b.t`, `SELECT * FROM t` reads `b.t`, but the walker recorded an access on `a.t`. The guard then found no table in `a` and stayed silent, so a column-less `b.t` came back raw. The same misresolution points the query access check at a schema the statement never reads.

`SearchRelation` is the fix: table, view, materialized view, foreign table and sequence, per schema in path order. `SearchObject` keeps its meaning for callers resolving a name that could be either kind. Both PostgreSQL relation sites use the new one, the access-table walker and the prior-backup target resolver.

Verified on PostgreSQL 17: `'t'::regclass` resolves to schema `b` while `pg_proc` holds `t` in `a`; and a sequence does shadow a table, since it is a relation, so `SearchRelation` keeps that case. The test goes RED against `SearchObject`.

## Why a new field, not `NotFoundError`

The ticket proposed reusing `NotFoundError`, which already arms a re-sync and a refusal. I built that and it fails.

`NotFoundError` has a third enforcement site at `sql_service.go:835` that is **not** gated on masking. Reusing the field would refuse a `CREATE TABLE t()` read for unlicensed workspaces and for CockroachDB, neither of which masks.

On MySQL the same field mostly means a typo'd table name. That arm skips when the driver already returned an error, which keeps the driver's own message visible and avoids a full re-sync per typo. Both of this PR's changes on the new arm (refuse whatever the result shape, re-sync before the error skip) would be wrong there.

A separate field keeps the two conditions apart.

## Why there is no CTE-scope filter

`ExtractAccessTables` does not model CTE scope. `WITH t AS (...) SELECT * FROM t` therefore reports a read of `public.t`, and if `public.t` is column-less this refuses a query that never touched it. #21197 tried to fix that with a scope walker over the analyzed query.

The walker is a pure filter. It can only ever drop an access, never add one. So every bug in it is a **fail-open**, and it had three at the head commit. Measured through the real span registry, once against the #21197 head (`8b69e382ad`) and once against this branch:

| statement | #21197 head | this PR |
|--|--|--|
| `WITH t AS (SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM t)) AS c FROM (SELECT 1) x) SELECT * FROM t` | ran unmasked | refused |
| `WITH t AS (SELECT string_agg('x', ',' ORDER BY (SELECT count(*) FROM t)) AS c FROM (SELECT 1) x) SELECT * FROM t` | ran unmasked | refused |
| `WITH "T" AS (SELECT 1 AS n) SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM t)) FROM "T"` | ran unmasked | refused |

PostgreSQL 17 adjudicates all three: `EXPLAIN` scans physical `t` in every one. The third is Codex's P1 on the #21197 head, which was never answered. All three are pinned as tests here.

What the cut costs is the false refusal Codex originally asked about: a query reading only a CTE named like a column-less relation. `queryRetry` re-syncs before refusing, so on a degraded snapshot that refusal lasts one query. It is permanent only against a genuinely column-less table, and this PR already refuses a direct read of one. `WITH t AS (SELECT 1) SELECT * FROM t` is the whole loss, and PostgreSQL confirms it scans nothing.

Four of Codex's ten comments on #21197 were caused by the walker: three fail-opens it introduced and one over-refusal. Deleting it retires all four.

## Open question: should the check live in the span at all?

Pre-review made the case that it should not, and it is the strongest argument against this shape, so it belongs here rather than in a thread.

`unresolvedColumnsError` reads exactly two things: `span.SourceColumns`, which every engine populates, and the stored snapshot through `GetDatabaseMetadataFunc`. `MaskResults` holds both already: the same `*store.Store`, and a `maskingDataProvider` that loads the same `*model.DatabaseMetadata` and already walks `GetSchemaMetadata` then `GetTable` in `getColumn`. Nothing extractor-only is used. So the same decision could be a function in `query_result_masker.go` over `(span.SourceColumns, instance, store)`, deleting the `base` field, the extractor helpers and the three assignment sites.

That version would be smaller and would close two things this one leaves open for free: every masking engine at once (BYT-10204), because it reads a field every extractor fills, and the backup-table rewrite, because `replaceBackupTableWithSource` rewrites `span.SourceColumns` before `MaskResults` runs, so a consumer-side check would judge the rewritten relation.

There is one thing the extractor knows that the consumer does not, and it showed up in the proposal's own required amendment: the extractor knows the query was `EXPLAIN ANALYZE`, and leaves the field nil there. A consumer-side check over `SourceColumns` fires on that path and would have to re-derive the exemption from the statement text, using the `strings.HasPrefix(strings.TrimSpace(stmt), "EXPLAIN")` test in `MaskResults`. That test is case-sensitive and does not strip a leading comment, so `explain analyze ...` and a comment-prefixed `EXPLAIN ANALYZE` both slip past it. The span side gets the distinction from the parse.

Beyond that, I kept it in the span because that is where the other two verdicts of this class already live. `NotFoundError` and `FunctionNotSupportedError` both mean "the span could not be analyzed well enough to mask", both are set by extractors, and both are enforced in the same three places. Adding a third beside them keeps one class in one layer; moving this one to `api/v1` splits it. Shipping PostgreSQL-only also keeps the blast radius at one engine rather than eleven, which is the point of the staged plan in BYT-10073.

If we do move it, the shape is already there: `newMaskingDataProviderFromColumns` takes a `parserbase.SourceColumnSet` today, and calling the helper after `replaceBackupTableWithSource` rather than before it is what closes the backup-table case. It would also delete roughly 48 of the comment lines counted below, since most of them exist to say which of six return paths gets the signal. The gate would have to stay: other engines fill `SourceColumns` with table-level entries only, which suits a relation-level check but means the helper would start judging eleven engines at once unless it keeps `EngineSupportMasking` or an explicit engine switch.

**Decided: not in this PR.** The deciding reason is blast radius, not the argument above. A consumer-side helper judges every masking engine at once; this ships PostgreSQL, where the bug was reported and where the behavior is probed. Consumer-side is the right design for BYT-10204, where multi-engine coverage is the point, and it should subsume this field when it lands rather than sit beside it. Recorded on that ticket.

## Trade-off, stated

**A legally column-less table is refused, permanently.** Two routes reach that state on a healthy, fully privileged database: `CREATE TABLE t()`, and dropping a table's last column. Both are stored exactly like a degraded relation, and a re-sync reproduces the shape rather than repairing it, because the syncer's column query skips dropped attributes. Such a table still holds rows and still conveys cardinality through `count(*)`, joins and existence tests, so this is a real refusal rather than a free one.

**Open question for review: the driver result can tell the two apart, and this PR does not use it.** The snapshot cannot, but the result can. `RowsToQueryResult` fills `ColumnNames` from `rows.Columns()` and gates its row loop on `columnLength > 0`, so a zero-column result provably carries no values. A degraded snapshot still returns the table's real columns from the server, so it still refuses; a genuinely column-less table returns none and has nothing to withhold. Folding that into the shared predicate would remove the false refusal for `SELECT *`, leaving only `count(*)`-shaped reads refused.

**Decided: leave it out.** It puts result shape back into a guard deliberately made independent of it, and two Codex rounds on #21197 showed that guard is easy to get wrong there. What it buys is `SELECT *` on a table with no columns, a degenerate query. The condition would also have to move into `maskingBlockedByUnresolvedColumns` so the re-sync and the refusal keep agreeing, which is more surface than the case is worth.

**A permanent condition re-syncs per query.** Unthrottled, on the request path. Not introduced here. The `NotFoundError` arm above has always behaved this way, and the new arm matches it deliberately. Tracked as BYT-10074.

The re-sync is load-bearing rather than belt-and-braces, which is worth saying before anyone proposes dropping it. Neither other repair path reaches a PostgreSQL database: nothing in `backend/plugin/parser/pg` produces `NotFoundError`, so that arm never fires here, and periodic schema sync is opt-in, with `getOrDefaultSyncInterval` returning `0 * time.Second`, commented "means never sync". Without the on-request sync a snapshot degraded by a role change would stay degraded until someone pressed the button, which is exactly what the customer had to do.

## Deliberately out of scope

- **Absent relations.** A relation missing from the snapshot entirely never reaches the access set, so it stays unmasked. Marked `DEFER:` at `findUnresolvedRelations`.
- **Reads the access set never reports.** A SQL-language function body (BYT-10075), a FROM-clause function argument or a `VALUES` list (BYT-10076). Both pre-existing, both pinned by a test that fails if either is fixed upstream.
- **Other engines** (BYT-10204). Only the PostgreSQL extractor sets the signal. MySQL, Oracle, SQL Server, Redshift and the rest keep the fail-open; a test records which engines would act on one. MySQL has a live producer today: a role with only `TRIGGER` or DDL grants syncs the table with zero columns. Verified on 8.0.46.
- **Partial column loss.** A snapshot keeping some of a table's columns resolves, and the maskers land positionally on the wrong columns. That is F5 in the ticket and needs catalog-versus-metadata comparison. `NATURAL JOIN` misaligns them on a healthy snapshot too (BYT-10202).
- **The sync's isolation level** (BYT-10205). `SyncDBSchema` opens with `BeginTx(ctx, nil)`, so read committed, and reads columns before tables. A table created between the two passes is stored with no columns. That is the last remaining producer of this state on PostgreSQL after #20581, and a one-line `RepeatableRead` closes it.
- **The backup-table rewrite** (recorded on BYT-10204). `replaceBackupTableWithSource` rewrites `span.SourceColumns` after the signal is computed, so a healthy `bbdataarchive` backup table over a column-less source stays silent. A consumer-side check placed after the rewrite closes it, which is one reason that is the right shape for the multi-engine work.
- **Reads omni's AST walker hides** (BYT-10201, raised to Urgent). `walkChildren` in omni's generated pg walker has no `case *List`, so `ast.Inspect` stops there and `ExtractAccessTables` never sees a relation behind one. `WHERE id IN ((SELECT count(*) FROM d), 2)` and `WHERE id BETWEEN (SELECT count(*)::int FROM d) AND 10` both scan `d` in PostgreSQL's plan and report an access set without it. The same subquery under `=` is caught. That is one line in omni and it widens BYT-10076 well past its title, since the access set also drives query access control.
- **Masking through views** (BYT-10203). A view query's lineage names the view, and neither the metadata tree nor `SchemaCatalog` carries view columns, so `SELECT * FROM a_view` is unmasked whatever the snapshot says. That is why this change judges tables alone, and it needs a product decision rather than a patch.
- **`FOR UPDATE OF <alias>`.** A locking clause's target is walked as a table reference, so an alias spelling a column-less table's name is refused. PostgreSQL rejects a lock target that is not already in `FROM`, so those access-set entries are always redundant. Pre-existing over-record in `ExtractAccessTables`; this change escalates it to a refusal.

## Testing

`gofmt`, `go vet`, `golangci-lint` (0 issues), and the `backend/api/v1`, `backend/plugin/parser/pg`, `backend/plugin/parser/base` suites all pass.

The pg tests derive spans from real SQL through the registry rather than hand-built structs, and 16 subtests go RED with the signal disabled (`unresolved = nil` in `unresolvedColumnsError`). The two api/v1 tests pin the shared predicate instead, so they stay green under that revert by design: one keeps the re-sync trigger and the refusal on the same condition, the other keeps enforcement keyed on `EngineSupportMasking` rather than on which extractor sets the signal.

Probed against live PostgreSQL 17 across the accept and the reject space, with `EXPLAIN` as the oracle for what each statement actually reads: 400+ statements over healthy and degraded snapshots, plus a differential against the #21197 head.

One gap worth naming: **no test reaches `MaskResults` itself.** It calls three concrete `*store.Store` methods before its loop, so it needs PostgreSQL to run, and nothing in the repo exercises it today (BYT-10073 recorded the same: "no existing test covers the masker at all"). I confirmed the cost of that during this work by deleting the refusal from the working tree, where every gate stayed green. What is pinned is the signal, by the pg tests, and the predicate both consumers key on, by the api/v1 tests. Pinning the call site needs the narrow-interface seam AGENTS.md describes, which belongs in its own change.

Cost on the healthy path is unchanged. `getDatabaseMetadata` is memoized per extractor, so a healthy ten-table join issues the same twelve metadata fetches as `main` and runs at 406 us against 404 us.

Comment share on the added production lines is 44%, well over the 20% tripwire. I re-read every line against the three permitted kinds three times and cut what restated the code or argued a point; what is left is a constraint, an external fact, or a `DEFER:` entry. The ratio is high partly because the code shrank: the hard part of this change is knowing which relation kinds to judge and why not the others, and that knowledge is the deliverable. The two longest blocks carry why a CTE-scope filter must not come back, and why this state still occurs after #20581.

One assignment is defensive rather than exercised: `tryUserFuncTableSource`'s return path. I could not construct a statement that reaches it with a non-empty access set, because a SQL-language function body contributes no accesses today (BYT-10075) and a statement naming a degraded table alongside the function takes the fallback path instead. It becomes load-bearing when BYT-10075 lands, so removing it would plant a fail-open with a timer on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdrmFx2TvWxeZDMvp3S1aG
