### PR TITLE
test(migrator): cover prerelease backport versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Bytebase is the standard for database development. Every product and engineering
 
 - The metadata schema is `backend/migrator/migration/LATEST.sql`; migrations live in `backend/migrator/migration/<major.minor>/`.
 - New migrations require updating `TestLatestVersion` in `backend/migrator/migrator_test.go`; DDL changes also update `LATEST.sql`.
+- A release-patch metadata backport uses `migration/<next-main-migration>-backport/` and a four-digit ordinal, so `migration/3.23.1-backport/0000##workload_identity_audiences.sql` is `3.23.1-backport.0`. Allocate it strictly between the highest metadata version shipped on the release branch and the first main migration that branch still needs, increment the ordinal for later backports, and retain every prior file. The prerelease is migration-order metadata, not an unstable product release. If it needs a Go step, the `goMigrations` key must match the full parsed version, including its prerelease and ordinal.
 - Metadata JSONB uses `protojson.Marshal`: keys are camelCase (`taskRun`), not proto snake_case (`task_run`).
 - Follow Google language style guides and AIPs for API/proto design. AIPs take precedence over the proto guide. Enum values use `HELLO`, not `TYPE_HELLO`.
 - Use American English. Avoid collection names ending in `List`.

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -28,3 +28,70 @@ func TestVersionUnique(t *testing.T) {
 		versions[file.version.String()] = struct{}{}
 	}
 }
+
+func TestGetVersionFromPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		version string
+		wantErr bool
+	}{
+		{
+			name:    "main migration",
+			path:    "migration/3.23/0004##workload_identity_audiences.sql",
+			version: "3.23.4",
+		},
+		{
+			name:    "release patch backport",
+			path:    "migration/3.23.1-backport/0000##workload_identity_audiences.sql",
+			version: "3.23.1-backport.0",
+		},
+		{
+			name:    "release patch backport ordinal",
+			path:    "migration/3.23.1-backport/0010##later_backport.sql",
+			version: "3.23.1-backport.10",
+		},
+		{
+			name:    "invalid filename ordinal",
+			path:    "migration/3.23.1-backport/000a##later_backport.sql",
+			wantErr: true,
+		},
+		{
+			name:    "invalid nested path",
+			path:    "migration/3.23.1-backport/nested/0000##later_backport.sql",
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			version, err := getVersionFromPath(test.path)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, semver.MustParse(test.version), *version)
+		})
+	}
+}
+
+func TestReleasePatchMigrationVersionOrder(t *testing.T) {
+	paths := []string{
+		"migration/3.23/0000##review_run.sql",
+		"migration/3.23.1-backport/0000##workload_identity_audiences.sql",
+		"migration/3.23.1-backport/0009##later_backport.sql",
+		"migration/3.23.1-backport/0010##later_backport.sql",
+		"migration/3.23/0001##issue_comment_thread.sql",
+	}
+
+	versions := make([]semver.Version, 0, len(paths))
+	for _, path := range paths {
+		version, err := getVersionFromPath(path)
+		require.NoError(t, err)
+		versions = append(versions, *version)
+	}
+
+	for i := 1; i < len(versions); i++ {
+		require.Truef(t, versions[i-1].LT(versions[i]), "%s must sort before %s", versions[i-1], versions[i])
+	}
+}

--- a/docs/operations/upgrade.md
+++ b/docs/operations/upgrade.md
@@ -2,6 +2,10 @@
 
 This runbook focuses on upgrade-time checks for environments that may run Bytebase with more than one active replica.
 
+For the WIF audience backport in 3.22.1, follow the
+[WIF rollout and 3.22.1 upgrade](./wif-3.22.1-upgrade.md) guidance before
+rolling out replicas.
+
 ## Scope
 
 - Covers operator checks before, during, and after an upgrade.

--- a/docs/operations/wif-3.22.1-upgrade.md
+++ b/docs/operations/wif-3.22.1-upgrade.md
@@ -1,0 +1,64 @@
+# WIF rollout and 3.22.1 upgrade
+
+The 3.22.1 WIF fix uses metadata migration
+`3.23.1-backport.0`. That is a migration-order prerelease, not an unstable
+Bytebase product release. It lets the released 3.22.1 patch run the WIF
+backfill after metadata `3.23.0`. A later main upgrade then runs the unchanged
+main migrations `3.23.1` through `3.23.4`.
+
+## Record provenance before upgrading
+
+Use a read-only connection to record the complete metadata ledger:
+
+```sql
+SELECT id, version
+FROM instance_change_history
+ORDER BY id;
+```
+
+Record that output with the exact Bytebase artifact digest (or package
+checksum) and the source tag, branch, and commit that produced it. Label a
+database by both its metadata version and its artifact digest/source. The
+ledger records version markers; interpret them with the artifact and source,
+which identify the build that created them.
+
+Do not lower, edit, or rewrite the metadata ledger.
+
+## Supported upgrade paths
+
+| Metadata ledger state before the patch | Expected metadata sequence | Action |
+| --- | --- | --- |
+| `3.22.14` | Patch: `3.23.0` → `3.23.1-backport.0`; later main: unchanged `3.23.1` → `3.23.2` → `3.23.3` → `3.23.4` | Upgrade normally to the 3.22.1 patch, then use the normal main upgrade path when available. |
+| `3.23.0` | Patch: `3.23.1-backport.0`; later main: unchanged `3.23.1` → `3.23.2` → `3.23.3` → `3.23.4` | Upgrade normally to the 3.22.1 patch, then use the normal main upgrade path when available. |
+| A main migration from `3.23.1` through `3.23.4` | Continue with the unchanged main migration files that are still ahead of the ledger. | Upgrade to a supported main build. Do not downgrade to the 3.22.1 patch. |
+| A fresh 3.22.1 patch metadata database | The patch schema initializes with marker `3.23.1-backport.0`; a later main upgrade runs unchanged `3.23.1` through `3.23.4`. | No separate WIF backfill is needed because there are no existing workload identities. |
+
+The patch deliberately places `3.23.1-backport.0` between `3.23.0` and
+`3.23.1`. The main `3.23.1` through `3.23.4` files retain their original
+names, contents, and order.
+
+Databases initialized or upgraded by the superseded renumbering revision
+`5e1f64fed1`, the integer-`.1` backport revision `343cb7c42e`, or builds using
+either numbering are outside these supported paths. This includes backups
+restored from those states. Preserve their ledger output, artifact digest, and
+source ref, then complete a separate recovery assessment before deploying this
+patch or a main build. Do not use a ledger rewrite to move those databases onto
+this path.
+
+## WIF rollout checks
+
+1. Replace older Bytebase replicas before creating or editing workload
+   identities. Older replicas can write identities without audiences after the
+   one-time backfill, or discard audiences from a backfilled list.
+2. Keep every audience requested by a pipeline in that identity's allowlist.
+   The backfill preserves `bytebase` and provider defaults when they can be
+   derived. Add custom audiences and GitHub Enterprise Server defaults
+   explicitly.
+3. Update Terraform configuration to retain the required issuer, allowed
+   audiences, and subject bindings. A later apply must not remove values the
+   backfill preserved.
+4. Verify that a token with an allowed audience exchanges successfully and a
+   token addressed only to an unrelated audience is rejected. Repair invalid
+   or overly broad subject patterns before relying on the identity.
+
+See the [general upgrade guidance](./upgrade.md) for replica health checks.


### PR DESCRIPTION
Release backports sometimes need a metadata migration after the latest version shipped on the release branch but before a main migration that branch still needs. The existing parser supports SemVer prerelease identifiers: `migration/3.23.1-backport/0000##workload_identity_audiences.sql` produces `3.23.1-backport.0`, which sorts strictly between `3.23.0` and `3.23.1`.

Add parser and ordering regression tests for that convention, including numeric ordinal ordering, and document its allocation rules and WIF rollout guidance. The prerelease string identifies metadata ordering; it does not mark the Bytebase product release unstable.

Main's existing migration files, `LATEST.sql`, and runtime migrator remain unchanged. The companion #21408 uses the prerelease path, allowing unchanged main to apply its original comment, plan, role, and WIF migrations in order.

## Validation

- All migrator parser/latest-version/uniqueness/order tests passed.
- Both required root Go lint passes and the server build passed.
- Verified the complete migration directory is unchanged against the current main base.
- Ten real PostgreSQL 17 upgrade scenarios passed using the actual revised migrators: metadata `3.22.14` and `3.23.0` through the patch; fresh patch installation; original main `.1`–`.4`; patch → older main; restart; and an audience-less row created during rollout. Assertions covered exact ledgers, schema/constraints/indexes, WIF audiences/provider typing, explicit-audience preservation, role permissions, and disabled project settings.

The [upgrade guide](https://github.com/bytebase/bytebase/blob/9c52dabc80826e4a9daea073f169e8e6e34d6b58/docs/operations/wif-3.22.1-upgrade.md) also distinguishes metadata version markers from image provenance and identifies superseded PR builds that require a separate recovery assessment. Managed deployment and CI history checks found no use of the original PR builds; private deployments remain subject to the operator inventory.
