### PR TITLE
test(common): drop duplicated doc comments in the relocated UTF-8 tests

### DIFF
--- a/backend/common/util_test.go
+++ b/backend/common/util_test.go
@@ -346,9 +346,6 @@ func fillAllStringFields(m protoreflect.Message, value string, depth int) {
 
 // countInvalidStringFields walks m and returns how many string values
 // (fields, list elements, map keys and values) hold invalid UTF-8.
-
-// countInvalidStringFields walks m and returns how many string values
-// (fields, list elements, map keys and values) hold invalid UTF-8.
 func countInvalidStringFields(m protoreflect.Message) int {
 	count := 0
 	m.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
@@ -400,12 +397,6 @@ func countInvalidStringFields(m protoreflect.Message) int {
 // defaults, definitions — not just comments: fill each one with the raw-GBK
 // shape go-ora leaks for values ending in a dangling lead byte, then assert
 // sanitization leaves zero invalid strings and proto marshaling succeeds.
-
-// TestSanitizeUTF8MessageCoversEveryStringField proves the BYT-9916 fix
-// covers every string field of the database metadata — names, types,
-// defaults, definitions — not just comments: fill each one with the raw-GBK
-// shape go-ora leaks for values ending in a dangling lead byte, then assert
-// sanitization leaves zero invalid strings and proto marshaling succeeds.
 func TestSanitizeUTF8MessageCoversEveryStringField(t *testing.T) {
 	// 测试 + dangling lead byte 0xb1: the exact wholly-unconverted raw GBK
 	// shape go-ora returns (engine-verified against Oracle 11gR2/ZHS16GBK).
@@ -430,10 +421,6 @@ func TestSanitizeUTF8MessageCoversEveryStringField(t *testing.T) {
 	_, err = protojson.Marshal(metadata)
 	require.NoError(t, err)
 }
-
-// TestSanitizeUTF8MessageNameFields pins the customer-visible BYT-9916 shape:
-// object names (schema/table/column) carrying raw GBK bytes must marshal
-// after sanitization, and valid names must pass through untouched.
 
 // TestSanitizeUTF8MessageNameFields pins the customer-visible BYT-9916 shape:
 // object names (schema/table/column) carrying raw GBK bytes must marshal


### PR DESCRIPTION
Follow-up to #21410, which merged before this fix could be pushed.

Moving the sanitization assertions out of the Oracle driver package left three doc comments written twice, back to back: `countInvalidStringFields`, `TestSanitizeUTF8MessageCoversEveryStringField` and `TestSanitizeUTF8MessageNameFields`. The extraction ran each block up to the next top-level `func`, so it carried the following declaration's comment along as its tail and the next block repeated it.

Caught by Codex on #21410 ([P3](https://github.com/bytebase/bytebase/pull/21410#discussion_r3977036215)); the fix landed after the squash merge, so it needs its own PR.

Rather than patch the three reported sites, I scanned every `.go` file in the original diff for comment blocks repeated verbatim across only blank lines. That found exactly three, all in this file. Re-scan reports 0; each declaration now has one comment. `go test ./backend/common/` passes, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)