### PR TITLE
fix(frontend): simplify instance TLS and SSH labels

### DIFF
--- a/docs/research/2026-09-11-instance-connection-labels.md
+++ b/docs/research/2026-09-11-instance-connection-labels.md
@@ -1,0 +1,26 @@
+# Instance connection labels
+
+Research checked 2026-09-11. Recommendation is editorial judgment, not a claim of a universal industry convention.
+
+## Independent reviews
+
+Three independent reviewers researched DBeaver/DataGrip, TablePlus/pgAdmin, and MySQL Workbench/MongoDB Compass. All recommended TLS and SSH tunnel for Bytebase's section labels.
+
+## Verified first-party labels
+
+- DBeaver documents **SSL** and **SSH** configuration tabs. [SSL configuration](https://dbeaver.com/docs/dbeaver/SSL-Configuration/), [SSH configuration](https://dbeaver.com/docs/dbeaver/SSH-Configuration/)
+- DataGrip uses an **SSH/SSL** tab with **Use SSL** and **Use SSH tunnel** controls. [DataGrip documentation](https://www.jetbrains.com/help/datagrip/configuring-ssh-and-ssl.html)
+- pgAdmin documents an **SSL mode** field, **SSH Tunnel** tab, and **Use SSH tunneling** toggle. [pgAdmin server dialog](https://www.pgadmin.org/docs/pgadmin4/9.17/server_dialog.html)
+- TablePlus documents **SSH Tunneling** and describes its `tLSMode` connection parameter as **TLS mode**; these are documentation terms, not verified current form labels. [TablePlus connection documentation](https://docs.tableplus.com/gui-tools/manage-connections)
+- MySQL Workbench names its encryption tab **SSL** and its selector **Use SSL**. Its documented values include No, If available, Require, and certificate-verification variants. The short protocol name labels the section while the control indicates behavior. [MySQL Workbench manual](https://dev.mysql.com/doc/workbench/en/wb-mysql-connections-methods-standard.html)
+- Workbench calls the SSH connection method **Standard TCP/IP over SSH**. The SSH method still has its own SSL tab: the features compose rather than being alternatives. [MySQL Workbench SSH manual](https://dev.mysql.com/doc/workbench/en/wb-mysql-connections-methods-ssh.html)
+- MongoDB Compass documentation explicitly instructs users to select the **TLS / SSL** tab. It documents Default, On, and Off values. The page title is “TLS / SSL Connection Tab,” but the actual tab label omits “Connection.” [Compass TLS documentation](https://www.mongodb.com/docs/compass/connect/advanced-connection-options/tls-ssl-connection/)
+- Compass explicitly names its other tab **Proxy / SSH Tunnel**. It documents SSH with Password and SSH with Identity File as options, and supports using SSH tunnels together with TLS. [Compass SSH documentation](https://www.mongodb.com/docs/compass/connect/advanced-connection-options/ssh-connection/)
+
+## Application to Bytebase
+
+Use **TLS** for the visible section and help title, **TLS mode** as the selector accessible label, and **SSH tunnel** for the SSH section, selector accessible label, and help title. Keep TLS choices Disabled / TLS / Mutual TLS and SSH choices Disabled / Enabled.
+
+“TLS options” adds a generic noun already conveyed by the form. “TLS connection” repeats connection context. “TLS mode” is appropriate for the selector but unnecessarily narrows the heading above certificate and identity fields. “SSH tunnel” adds meaningful specificity over bare SSH: it names the network route to the database. “SSH connection” is less specific about the route. Equal word counts are not needed for sibling sections when the extra word conveys a useful distinction.
+
+This is a small label change; no behavioral or layout changes are needed. Existing help text and link labels should be checked so opening help does not switch back to a different section name.

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -642,7 +642,7 @@
       "ssh-key": "SSH Key",
       "user": "User"
     },
-    "ssh-connection": "SSH Connection",
+    "ssh-connection": "SSH tunnel",
     "ssh-type": {
       "none": "None",
       "tunnel-and-private-key": "Tunnel + Private Key"
@@ -673,7 +673,7 @@
       "client-key-path": "Private key path",
       "client-key-placeholder": "Input or drag and drop YOUR_CLIENT_KEY",
       "configured": "Configured",
-      "connection-security": "Connection security",
+      "connection-security": "TLS",
       "mutual-tls-unavailable-engine": "Mutual TLS is not available for this engine.",
       "posture": {
         "disabled": "Disabled",
@@ -685,7 +685,7 @@
       "verification-disabled-description": "Verification is disabled. The connection is encrypted, but the server identity is not verified; CA settings are ignored. This is insecure. Enable verification for secure connections; disable it only temporarily for development or troubleshooting.",
       "verify-certificate": "Verify server certificate"
     },
-    "ssl-connection": "SSL Connection"
+    "ssl-connection": "TLS"
   },
   "database": {
     "access-denied": "You don't have the permission to access this database.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -642,7 +642,7 @@
       "ssh-key": "Clave del SSH",
       "user": "Nombre de usuario"
     },
-    "ssh-connection": "Conexión SSH",
+    "ssh-connection": "Túnel SSH",
     "ssh-type": {
       "none": "Ninguno",
       "tunnel-and-private-key": "Túnel + Clave Privada"
@@ -673,7 +673,7 @@
       "client-key-path": "Ruta de la clave privada",
       "client-key-placeholder": "Ingrese o arrastre y suelte YOUR_CLIENT_KEY",
       "configured": "Configurado",
-      "connection-security": "Seguridad de la conexión",
+      "connection-security": "TLS",
       "mutual-tls-unavailable-engine": "El TLS mutuo no está disponible para este motor.",
       "posture": {
         "disabled": "Deshabilitado",
@@ -685,7 +685,7 @@
       "verification-disabled-description": "La verificación está desactivada. La conexión está cifrada, pero no se verifica la identidad del servidor y se ignora la configuración de CA. Esto es inseguro. Activa la verificación para conexiones seguras; desactívala solo temporalmente durante el desarrollo o la resolución de problemas.",
       "verify-certificate": "Verificar certificado del servidor"
     },
-    "ssl-connection": "Conexión SSL"
+    "ssl-connection": "TLS"
   },
   "database": {
     "access-denied": "No tiene permiso para acceder a esta base de datos.",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -642,7 +642,7 @@
       "ssh-key": "SSHキー",
       "user": "ユーザー名"
     },
-    "ssh-connection": "SSH接続",
+    "ssh-connection": "SSH トンネル",
     "ssh-type": {
       "none": "なし",
       "tunnel-and-private-key": "トンネル + 秘密鍵"
@@ -673,7 +673,7 @@
       "client-key-path": "秘密鍵のパス",
       "client-key-placeholder": "YOUR_CLIENT_KEYを入力またはドラッグ＆ドロップ",
       "configured": "設定済み",
-      "connection-security": "接続セキュリティ",
+      "connection-security": "TLS",
       "mutual-tls-unavailable-engine": "このエンジンでは相互 TLS は利用できません。",
       "posture": {
         "disabled": "無効",
@@ -685,7 +685,7 @@
       "verification-disabled-description": "検証が無効です。接続は暗号化されますが、サーバーの身元は検証されず、CA 設定は無視されます。これは安全ではありません。安全な接続のために検証を有効にし、開発やトラブルシューティング時にのみ一時的に無効にしてください。",
       "verify-certificate": "サーバー証明書を検証"
     },
-    "ssl-connection": "SSL接続"
+    "ssl-connection": "TLS"
   },
   "database": {
     "access-denied": "データベースにアクセスする権限がありません",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -642,7 +642,7 @@
       "ssh-key": "Khóa SSH",
       "user": "Người dùng"
     },
-    "ssh-connection": "Kết nối SSH",
+    "ssh-connection": "Đường hầm SSH",
     "ssh-type": {
       "none": "Không có",
       "tunnel-and-private-key": "Đường hầm + Khóa riêng"
@@ -673,7 +673,7 @@
       "client-key-path": "Đường dẫn khóa riêng",
       "client-key-placeholder": "Nhập hoặc kéo thả YOUR_CLIENT_KEY",
       "configured": "Đã cấu hình",
-      "connection-security": "Bảo mật kết nối",
+      "connection-security": "TLS",
       "mutual-tls-unavailable-engine": "TLS lẫn nhau không khả dụng cho engine này.",
       "posture": {
         "disabled": "Đã tắt",
@@ -685,7 +685,7 @@
       "verification-disabled-description": "Xác minh đã tắt. Kết nối vẫn được mã hóa nhưng danh tính máy chủ không được xác minh; cài đặt CA bị bỏ qua. Điều này không an toàn. Hãy bật xác minh để bảo đảm kết nối an toàn; chỉ tạm tắt khi phát triển hoặc khắc phục sự cố.",
       "verify-certificate": "Xác minh chứng chỉ máy chủ"
     },
-    "ssl-connection": "Kết nối SSL"
+    "ssl-connection": "TLS"
   },
   "database": {
     "access-denied": "Bạn không có quyền truy cập cơ sở dữ liệu này.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -642,7 +642,7 @@
       "ssh-key": "SSH 密钥",
       "user": "用户名"
     },
-    "ssh-connection": "SSH 连接",
+    "ssh-connection": "SSH 隧道",
     "ssh-type": {
       "none": "不使用",
       "tunnel-and-private-key": "隧道 + 私钥"
@@ -673,7 +673,7 @@
       "client-key-path": "私钥路径",
       "client-key-placeholder": "输入或拖放 YOUR_CLIENT_KEY",
       "configured": "已配置",
-      "connection-security": "连接安全性",
+      "connection-security": "TLS",
       "mutual-tls-unavailable-engine": "此引擎不支持双向 TLS。",
       "posture": {
         "disabled": "已禁用",
@@ -685,7 +685,7 @@
       "verification-disabled-description": "验证已关闭。连接仍然加密，但不会验证服务器身份，CA 设置将被忽略。这存在安全风险。请启用证书验证，仅在开发或故障排查时临时关闭。",
       "verify-certificate": "验证服务器证书"
     },
-    "ssl-connection": "SSL 连接"
+    "ssl-connection": "TLS"
   },
   "database": {
     "access-denied": "您无权访问该数据库",


### PR DESCRIPTION
Replace the instance form’s “Connection security” and “SSH Connection” labels with “TLS” and “SSH tunnel” across all five locales. Align the TLS help title and shared toggle label, while preserving existing connection behavior.

Includes a source-backed comparison of database-client terminology supporting the wording choice.

Validation: `pnpm --dir frontend fix` and `pnpm --dir frontend test` passed, including all 521 test files and 4,379 tests.
