### PR TITLE
fix(frontend): correct cloud connection notice spacing

### DIFF
--- a/frontend/src/components/instance/InstanceFormBody.test.ts
+++ b/frontend/src/components/instance/InstanceFormBody.test.ts
@@ -184,12 +184,18 @@ describe("InstanceFormBody", () => {
       'className="flex flex-col gap-4"',
       connectionTitleIndex
     );
+    const authenticationIndex = source.indexOf(
+      "<DataSourceForm",
+      connectionTitleIndex
+    );
 
     expect(connectionTitleIndex).toBeGreaterThanOrEqual(0);
     expect(firewallAlertIndex).toBeGreaterThan(connectionTitleIndex);
     expect(firewallAlertIndex).toBeLessThan(firewallInfoIndex);
     expect(firewallInfoIndex).toBeGreaterThan(connectionTitleIndex);
-    expect(firewallInfoIndex).toBeLessThan(connectionGridIndex);
+    expect(connectionGridIndex).toBeGreaterThan(connectionTitleIndex);
+    expect(firewallAlertIndex).toBeGreaterThan(connectionGridIndex);
+    expect(firewallInfoIndex).toBeLessThan(authenticationIndex);
     expect(source).toContain(
       'href="https://docs.bytebase.com/get-started/cloud#prerequisites"'
     );

--- a/frontend/src/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/components/instance/InstanceFormBody.tsx
@@ -1450,20 +1450,19 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
 
         {/* Connection Card */}
         <FormSection layout="stacked" title={t("instance.section.connection")}>
-          {isSaaSMode && (
-            <Alert variant="info" className="mt-2">
-              <a
-                href="https://docs.bytebase.com/get-started/cloud#prerequisites"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="normal-link"
-              >
-                {t("instance.sentence.firewall-info")}
-              </a>
-            </Alert>
-          )}
-
           <div className="flex flex-col gap-4">
+            {isSaaSMode && (
+              <Alert variant="info">
+                <a
+                  href="https://docs.bytebase.com/get-started/cloud#prerequisites"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="normal-link"
+                >
+                  {t("instance.sentence.firewall-info")}
+                </a>
+              </Alert>
+            )}
             {editingDataSource?.id === adminDataSource.id && (
               <DataSourceForm
                 authOnly


### PR DESCRIPTION
The Bytebase Cloud firewall notice touches the Authentication row because it sits outside the connection form's spaced container. Move it into the existing 16px gap layout and remove its extra top margin, keeping spacing consistent between the section heading, notice, and fields.

Update the existing test to verify that the notice appears inside the spaced container before authentication.

Validation: `pnpm --dir frontend fix` and `pnpm --dir frontend test` passed, including all 4,417 tests, type checking, UI guards, and the production bundle build. Browser verification was not performed.
