### PR TITLE
chore(plan): gate inline comment threads to dev builds

### DIFF
--- a/frontend/src/routes/project/plan-detail/components/PlanDetailStatementSection.tsx
+++ b/frontend/src/routes/project/plan-detail/components/PlanDetailStatementSection.tsx
@@ -39,6 +39,7 @@ import {
 import { GetSheetRequestSchema } from "@/types/proto-es/v1/sheet_service_pb";
 import { unknownDatabase } from "@/types/v1/database";
 import { extractDatabaseResourceName, hasProjectPermissionV2 } from "@/utils";
+import { inlineThreadsEnabled } from "@/utils/featureGates";
 import { engineSupportsSchemaEditor } from "@/utils/schemaEditor";
 import { getStatementSize, MAX_UPLOAD_FILE_SIZE_MB } from "@/utils/sheet";
 import { getInstanceResource } from "@/utils/v1/database";
@@ -487,7 +488,8 @@ export function PlanDetailStatementSection({
   const sheetSha256 = sheetSha256OfName(sheetName);
   const issue = page.issue;
   const threadsEnabled = Boolean(
-    issue &&
+    inlineThreadsEnabled() &&
+      issue &&
       !page.isCreating &&
       !isPendingDraft &&
       sheetSha256 &&

--- a/frontend/src/routes/project/plan-detail/components/review/ReviewActivityTimeline.test.tsx
+++ b/frontend/src/routes/project/plan-detail/components/review/ReviewActivityTimeline.test.tsx
@@ -129,6 +129,11 @@ vi.mock("../threads/CommentThreadCard", () => ({
   ),
 }));
 
+const gateMocks = vi.hoisted(() => ({
+  inlineThreadsEnabled: vi.fn(() => true),
+}));
+vi.mock("@/utils/featureGates", () => gateMocks);
+
 vi.mock("../threads/StatementAnchorContext", () => ({
   StatementAnchorContext: () => <div data-testid="anchor-context" />,
 }));
@@ -271,5 +276,48 @@ describe("ReviewActivityTimeline", () => {
     ).toHaveLength(1);
 
     act(() => root.unmount());
+  });
+
+  test("a release build renders a thread root as an ordinary comment", () => {
+    gateMocks.inlineThreadsEnabled.mockReturnValue(false);
+    const issue = create(IssueSchema, {
+      name: "projects/p1/issues/1",
+      creator: "users/issue-creator@example.com",
+      draft: false,
+    });
+    const plan = create(PlanSchema, { name: "projects/p1/plans/1" });
+    const rootName = "projects/p1/issues/1/issueComments/root";
+    const comments = [
+      create(IssueCommentSchema, {
+        name: rootName,
+        comment: "Root",
+        creator: "users/submitter@example.com",
+        threadState: IssueComment_ThreadState.OPEN,
+        statementAnchor: create(StatementAnchorSchema, { spec: "spec-1" }),
+      }),
+      create(IssueCommentSchema, {
+        name: "projects/p1/issues/1/issueComments/general",
+        comment: "General",
+        creator: "users/submitter@example.com",
+      }),
+    ];
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <ReviewActivityTimeline comments={comments} issue={issue} plan={plan} />
+      );
+    });
+
+    // The root keeps its stored thread state; with the gate off it must still
+    // reach the reader, as a plain comment rather than a card.
+    expect(container.querySelector("[data-testid='thread-card']")).toBeNull();
+    expect(
+      container.querySelectorAll("[data-testid='comment-row']")
+    ).toHaveLength(2);
+
+    act(() => root.unmount());
+    gateMocks.inlineThreadsEnabled.mockReturnValue(true);
   });
 });

--- a/frontend/src/routes/project/plan-detail/components/review/ReviewActivityTimeline.tsx
+++ b/frontend/src/routes/project/plan-detail/components/review/ReviewActivityTimeline.tsx
@@ -40,6 +40,7 @@ import { projectNamePrefix } from "@/stores/modules/v1/common";
 import { getTimeForPbTimestampProtoEs, unknownUser } from "@/types";
 import type { Issue, IssueComment } from "@/types/proto-es/v1/issue_service_pb";
 import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
+import { inlineThreadsEnabled } from "@/utils/featureGates";
 import { hasProjectPermissionV2 } from "@/utils/iam/permission";
 import { usePlanChangeReferenceData } from "../../hooks/usePlanChangeReferenceData";
 import { placementOf } from "../../shared/stores/placementSlice";
@@ -83,7 +84,10 @@ export function ReviewActivityTimeline({
     () => collectPlanUpdateSpecs(comments),
     [comments]
   );
-  const threads = useMemo(() => groupThreads(comments), [comments]);
+  const threads = useMemo(
+    () => (inlineThreadsEnabled() ? groupThreads(comments) : []),
+    [comments]
+  );
   // Anchored threads reference the plan's current specs; hydrate them once
   // here rather than once per card.
   const referenceSpecs = useMemo(

--- a/frontend/src/routes/project/plan-detail/components/threads/useUnresolvedThreadCounts.ts
+++ b/frontend/src/routes/project/plan-detail/components/threads/useUnresolvedThreadCounts.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useAppStore } from "@/stores/app";
 import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
 import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
+import { inlineThreadsEnabled } from "@/utils/featureGates";
 import { placementsForSheet } from "../../shared/stores/placementSlice";
 import { usePlanDetailStore } from "../../shared/stores/usePlanDetailStore";
 import {
@@ -16,7 +17,10 @@ const useIssueThreads = (issueName: string | undefined) => {
   const comments = useAppStore((state) =>
     issueName ? state.getIssueComments(issueName) : NO_COMMENTS
   );
-  return useMemo(() => groupThreads(comments), [comments]);
+  return useMemo(
+    () => (inlineThreadsEnabled() ? groupThreads(comments) : []),
+    [comments]
+  );
 };
 
 // Every unresolved thread on the issue; zero before an issue exists.

--- a/frontend/src/stores/app/issueComment.test.ts
+++ b/frontend/src/stores/app/issueComment.test.ts
@@ -704,3 +704,54 @@ test.each(["timeline", "threads"])(
     expect(store.getIssueComments(parent)).toEqual([old, remote]);
   }
 );
+
+test("a release build loads the timeline but never the reply pass", async () => {
+  vi.resetModules();
+  vi.doMock("@/utils/featureGates", () => ({
+    inlineThreadsEnabled: () => false,
+  }));
+  const { createIssueCommentSlice: createGatedSlice } = await import(
+    "./issueComment"
+  );
+  const state: Record<string, unknown> = {};
+  const set = (updater: unknown) => {
+    Object.assign(
+      state,
+      typeof updater === "function" ? updater(state) : updater
+    );
+  };
+  Object.assign(
+    state,
+    createGatedSlice(set as never, (() => state) as never, {} as never)
+  );
+  const store = state as ReturnType<typeof createIssueCommentSlice>;
+
+  const parent = "projects/p/issues/1";
+  const root = create(IssueCommentSchema, {
+    name: parent + "/issueComments/root",
+    threadState: IssueComment_ThreadState.OPEN,
+  });
+  const general = create(IssueCommentSchema, {
+    name: parent + "/issueComments/general",
+  });
+  mocks.listIssueComments.mockResolvedValueOnce({
+    issueComments: [root, general],
+    nextPageToken: "",
+  });
+
+  const loaded = await store.fetchIssueCommentThreads({ parent });
+
+  // One call: the timeline. No `root in [...]` follow-up.
+  expect(mocks.listIssueComments).toHaveBeenCalledTimes(1);
+  expect(mocks.listIssueComments.mock.calls[0][0]).toMatchObject({
+    parent,
+    filter: "",
+  });
+  // The plain timeline still reaches every comment surface, thread roots
+  // included — they simply render as ordinary comments.
+  expect(loaded).toEqual([root, general]);
+  expect(store.getIssueComments(parent)).toEqual(loaded);
+
+  vi.doUnmock("@/utils/featureGates");
+  vi.resetModules();
+});

--- a/frontend/src/stores/app/issueComment.ts
+++ b/frontend/src/stores/app/issueComment.ts
@@ -12,6 +12,7 @@ import {
   ListIssueCommentsRequestSchema,
   UpdateIssueCommentRequestSchema,
 } from "@/types/proto-es/v1/issue_service_pb";
+import { inlineThreadsEnabled } from "@/utils/featureGates";
 import { celStringList } from "@/utils/v1/celLiteral";
 import type { AppSliceCreator, IssueCommentSlice } from "./types";
 
@@ -174,8 +175,12 @@ export const createIssueCommentSlice: AppSliceCreator<IssueCommentSlice> = (
           return all;
         };
 
+        // The timeline load is what every comment surface reads, threads or
+        // not, so it runs unconditionally; only the reply pass is gated.
         const timeline = await listAll("");
-        const rootNames = timeline.filter(isThreadRoot).map((c) => c.name);
+        const rootNames = inlineThreadsEnabled()
+          ? timeline.filter(isThreadRoot).map((c) => c.name)
+          : [];
         const replies: IssueComment[] = [];
         for (let i = 0; i < rootNames.length; i += REPLY_QUERY_ROOTS) {
           const chunk = rootNames.slice(i, i + REPLY_QUERY_ROOTS);

--- a/frontend/src/utils/featureGates.test.ts
+++ b/frontend/src/utils/featureGates.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+import { expect, test, vi } from "vitest";
+
+test("inline threads follow the dev build flag", async () => {
+  vi.resetModules();
+  vi.doMock("./util", () => ({ isDev: () => false }));
+  const disabled = await import("./featureGates");
+  expect(disabled.inlineThreadsEnabled()).toBe(false);
+
+  vi.resetModules();
+  vi.doMock("./util", () => ({ isDev: () => true }));
+  const enabled = await import("./featureGates");
+  expect(enabled.inlineThreadsEnabled()).toBe(true);
+
+  vi.doUnmock("./util");
+  vi.resetModules();
+});
+
+// Vitest reports DEV, so every other suite exercises the feature as an engineer
+// on the dev server sees it. A release bundle is the opposite case, and only the
+// suites that stub the gate cover it.
+test("the suite runs with the gate on, matching the dev server", async () => {
+  const { inlineThreadsEnabled } = await import("./featureGates");
+  expect(import.meta.env.DEV).toBe(true);
+  expect(inlineThreadsEnabled()).toBe(true);
+});

--- a/frontend/src/utils/featureGates.ts
+++ b/frontend/src/utils/featureGates.ts
@@ -1,0 +1,11 @@
+import { isDev } from "./util";
+
+// Inline comment threads on plan detail are still stabilizing: the browser
+// journeys in plan-detail-review.spec.ts do not run in CI, and re-anchoring a
+// comment onto a newer revision is unverified against a saved sheet. Until
+// that closes the feature stays on the Vite dev server only.
+//
+// `isDev()` is a build-time constant, so a release bundle folds every call to
+// `false` and drops the thread UI rather than hiding it. Flipping this to
+// `true` is the whole un-gate.
+export const inlineThreadsEnabled = (): boolean => isDev();

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from "./role";
 export * from "./slug";
 export * from "./types";
 export * from "./util";
+export * from "./featureGates";
 export * from "./datetime";
 export * from "./label";
 export * from "./string";

--- a/frontend/tests/e2e/plan-detail/plan-detail-review.spec.ts
+++ b/frontend/tests/e2e/plan-detail/plan-detail-review.spec.ts
@@ -429,7 +429,10 @@ test.describe("Permission boundary: non-candidate cannot review but can comment"
 // A thread anchors to whole lines of the spec's saved sheet; it renders as a
 // gutter marker + expanded card in the statement editor and as a card with
 // its recorded context in the Review Activity timeline.
-test.describe("Inline comment threads (CUJ K)", () => {
+// Gated off with the feature: inlineThreadsEnabled() is false in the embedded
+// binary this suite runs against, so the thread UI is absent by design.
+// Re-enable together with the gate in src/utils/featureGates.ts.
+test.describe.skip("Inline comment threads (CUJ K)", () => {
   test.describe.configure({ mode: "serial" });
   let planId: string;
   let issueName: string;
@@ -843,7 +846,10 @@ test.describe("Long approval flow adaptive rendering (CUJ I)", () => {
 // Inline comment threads, second pass: several composers at once, the
 // reply composer's thread-state checkbox, the editor walker, and the
 // unresolved counts on the change tab and the Review summary.
-test.describe("Inline comment threads: composers, checkbox, walker, counts (CUJ L)", () => {
+// Gated off with the feature: inlineThreadsEnabled() is false in the embedded
+// binary this suite runs against, so the thread UI is absent by design.
+// Re-enable together with the gate in src/utils/featureGates.ts.
+test.describe.skip("Inline comment threads: composers, checkbox, walker, counts (CUJ L)", () => {
   test.describe.configure({ mode: "serial" });
   let planId: string;
   let issueName: string;
@@ -1044,7 +1050,10 @@ test.describe("Inline comment threads: composers, checkbox, walker, counts (CUJ 
 // A reader who may reply but not resolve sees neither the standalone
 // Resolve action nor the reply composer's state checkbox. No predefined role
 // separates the two comment permissions, so the test provisions its own.
-test.describe("Inline comment threads as a reply-only reader (CUJ L, restricted)", () => {
+// Gated off with the feature: inlineThreadsEnabled() is false in the embedded
+// binary this suite runs against, so the thread UI is absent by design.
+// Re-enable together with the gate in src/utils/featureGates.ts.
+test.describe.skip("Inline comment threads as a reply-only reader (CUJ L, restricted)", () => {
   const stamp = Date.now();
   const readerEmail = `e2e-reply-only-${stamp}@example.com`;
   const readerPassword = "12345678";
@@ -1129,7 +1138,10 @@ test.describe("Inline comment threads as a reply-only reader (CUJ L, restricted)
 // Inline comment threads, third pass: a range selected from the gutter, two
 // threads sharing one marker, the walker's announcement and its retreat
 // behind the find widget, and a narrow viewport.
-test.describe("Inline comment threads: ranges, shared markers, walker details, narrow view (CUJ M)", () => {
+// Gated off with the feature: inlineThreadsEnabled() is false in the embedded
+// binary this suite runs against, so the thread UI is absent by design.
+// Re-enable together with the gate in src/utils/featureGates.ts.
+test.describe.skip("Inline comment threads: ranges, shared markers, walker details, narrow view (CUJ M)", () => {
   test.describe.configure({ mode: "serial" });
   let planId: string;
   let issueName: string;


### PR DESCRIPTION
## What

Hides the plan-detail inline comment threads behind `isDev()`, so the feature is available on the Vite dev server and absent from every built bundle.

One gate, `inlineThreadsEnabled()` in `src/utils/featureGates.ts`, read at four sites:

| Site | Effect when off |
|---|---|
| `PlanDetailStatementSection` | no Monaco gutter markers, highlights, or composer |
| `ReviewActivityTimeline` | a thread root renders as an ordinary comment |
| `useUnresolvedThreadCounts` | change-tab and Review-summary counts are zero, so the badges hide |
| `fetchIssueCommentThreads` | the reply pass is skipped |

## Why

The feature has 180 unit tests and no executed browser coverage. There is no e2e workflow in `.github/workflows` at all, and `vitest.config.ts` excludes `tests/e2e/**`, so the 26 journeys in `plan-detail-review.spec.ts` have only ever run locally. #21386 also records the riskiest path as unverified: re-placing a comment onto a newer revision, against a saved sheet.

Rather than ship that to customers while it settles, engineers keep it on the dev server and everyone else does not see it.

## The store split

This is the one non-mechanical part. `useIssueCommentThreadsSync` is the *only* issue-comment fetch on the plan page — it lists the whole timeline, then pages replies for the roots it found. Gating the hook wholesale would blank the plain Review Activity feed along with the threads.

So the timeline load stays unconditional and only the `root in [...]` reply pass is gated. A thread root still reaches the reader when the gate is off; it just renders as a plain comment.

## What this does and does not do

`import.meta.env.DEV` is statically replaced at build time — verified zero literal occurrences in the release bundle — so the gate reliably evaluates `false` and the feature is unreachable.

It is **not** dead-code-eliminated. `bb-thread-card--flash` from `ThreadStack.tsx` is still present in the built output: the gate is a cross-module call feeding a runtime expression, and the thread components are statically imported, so tree-shaking cannot drop them. This is a runtime hide, not a strip. Taking the code out of the bundle would need lazy imports and is deliberately left out of scope.

## Tests

Vitest reports `DEV: true`, so every existing suite keeps exercising the feature exactly as an engineer on the dev server sees it — no coverage is lost. That left the release path untested, so three cases pin it:

- `featureGates.test.ts` — the gate tracks the build flag in both directions.
- `issueComment.test.ts` — with the gate off, one timeline call and no `root in [...]` follow-up; thread roots still reach the cache.
- `ReviewActivityTimeline.test.tsx` — with the gate off, an anchored root renders as a comment row and no thread card.

Four thread describes in `plan-detail-review.spec.ts` are `test.describe.skip`ped in place, not moved: the e2e harness builds without the `release` tag but still serves a `vite build`, so the thread UI is absent there by design. The BYT-9746 case stays — it edits a plain comment and is unaffected.

## Un-gating

Flip `inlineThreadsEnabled` to `true` and remove the four `.skip`s. The gate module comment records this.

## Breaking changes

None. Inline comment threads have never shipped — the latest tag is 3.22.1 and the frontend landed in #21386, which no tag contains. No API, proto, schema, or configuration change.

## Verification

`pnpm --dir frontend test`, the single gate CI runs — exit 0.

```
ok prepare (0.3s)  ok biome (2.0s)  ok guards (5.3s)
ok tsc (7.3s)      ok bundle (8.0s) ok vitest (55.7s)
Test Files 526 passed · Tests 4446 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
