### PR TITLE
docs(design): unfold and copy a statement in the task-run log

### DIFF
--- a/docs/design/task-run-log-statement-unfold.md
+++ b/docs/design/task-run-log-statement-unfold.md
@@ -1,0 +1,203 @@
+# Task-run log — a statement is a payload, not a line
+
+Status: proposal · 2026-09-11
+
+The task-run log cuts every executed statement to 80 characters and appends `...`. For the
+statements customers actually run — SDL, or a `CREATE TABLE` with a few hundred columns — the row
+says almost nothing, and the log offers no way to read or copy the rest.
+[#21276](https://github.com/bytebase/bytebase/pull/21276) removes the cut, which is the right
+diagnosis and a partial fix: the statement is still collapsed to a single run-on line with every
+newline replaced by a space, it now floods a 200px scroll box, and there is still no way to copy
+it. The rule this doc lands on: **the model returns two forms of every entry — the line the row
+shows and the text that line stands for — and destroys neither.** Truncation becomes a CSS
+property of the line. Copy and unfold act on the text. A statement row folds to one line by
+default and unfolds in place with its original formatting; an error row stays open, because an
+error is why the log was opened. The change is frontend-only and touches four surfaces that embed
+the viewer.
+
+## Problem
+
+`getCommandExecuteDetail` (`frontend/src/components/task-run-log/model.ts:305`) ends:
+
+```ts
+const normalized = statement.trim().replace(/\s+/g, " ");
+return normalized.length > 80
+  ? `${normalized.substring(0, 80)}...`
+  : normalized;
+```
+
+Two lossy steps, both in the model. `\s+ → " "` matches `\n` and `\r\n`, so a formatted statement
+becomes one line. The 80-character cut then throws away everything past the opening clause. The
+model hands `SectionContent` a single `detail: string`, so by the time a row renders, the
+statement is no longer in the component tree at all — nothing downstream can offer to show or copy
+it, and nothing can even tell that something was removed.
+
+The number 80 is not a product decision that was made and can be revisited; it is a constant that
+arrived with a refactor. The Vue cell it replaced
+(`.../TaskRunLogTable/StatementCell.vue`, deleted in
+[#18383](https://github.com/bytebase/bytebase/pull/18383)) clamped the row to one line too, but
+passed the untouched statement to a `TextOverflowPopover` and a `CopyButton` beside it. The
+rewrite kept the clamp, dropped both escape hatches, and hardcoded the width the clamp used to
+derive from the container.
+
+Two facts make the current row worse than it looks:
+
+- **The uniform-row assumption is already false.** `SectionContent` sizes its scroll box as
+  `ITEM_HEIGHT * MAX_VISIBLE_ITEMS` = 10 rows at 20px = 200px, but an error row returns
+  `command.response.error` through the same `detail` field and renders under `break-words`, so it
+  wraps to whatever height it needs. Rows of one fixed height are an assumption of the geometry,
+  not a property of the data.
+- **The UX contract already requires the missing half.** `docs/agents/frontend-ux.md`: *"Long
+  single-line identifiers use truncation with a tooltip or another way to inspect the complete
+  value."* The log has the truncation and not the way.
+
+What #21276 changes and does not: dropping the `substring` returns the whole statement, but the
+normalization above it stays, so a 200-line `CREATE TABLE` renders as one unbroken paragraph of
+prose; it reflows to dozens of visual lines inside a 200px window, pushing the timing column it is
+supposed to annotate off-screen; and copy is still absent, so the reader who needs the statement
+must leave for the sheet. The finding is real and the contributor should get the credit for it;
+this doc is the shape the fix takes.
+
+## Principle
+
+> **A row shows one line. The statement behind it is never destroyed to produce that line.**
+> The model returns both forms — `detail`, the line, and `fullDetail`, the original text — and the
+> view decides which to render. Collapsing whitespace and clamping width are properties of the
+> line alone. Copy and unfold always act on the original.
+
+What follows from it:
+
+- No length constant lives in the model. The line is clamped by the width it is given, which is
+  the only thing that knows how much fits.
+- Any row that carries an original can offer to copy it, whether or not it can be unfolded.
+- Whether a row starts folded is a statement about what the row is *for*, not about its length.
+- The log stays a scannable run history. Unfolding is a deliberate act on one row, not a mode.
+
+## Decisions
+
+**D1 · Two forms on the item.** `DisplayItem` (`types.ts`) gains `fullDetail?: string` beside the
+existing `detail: string`. `detail` keeps the `trim()` + `\s+ → " "` normalization — for a
+one-line row that is exactly right, and it keeps stray newlines from breaking the row geometry.
+`fullDetail` is the statement as the sheet stored it, untrimmed and unmodified. `getEntryDetail`
+returns both; the rest of the model is unchanged. Absent for rows that have no underlying text
+(`BEGIN`, `Completed`, retry counts), which is what makes it the test for both affordances below.
+
+**D2 · Truncation moves to CSS.** The row's line renders under `truncate`; the 80-character
+`substring` is deleted. A wide screen shows more of the statement and a narrow sheet shows less,
+which is what the reader expects and what the constant could never do.
+
+**D3 · Copy acts on the original, on any row that has one.** The shared `CopyButton`
+(`components/ui/copy-button.tsx`) already owns the clipboard write, the toast, the 2-second check
+state and the `common.copy` tooltip; it takes `content` as a thunk, so the string is resolved on
+click rather than held per row. It copies `fullDetail` — real newlines, untrimmed — regardless of
+whether the row is folded. This is the affordance that makes a statement useful outside the log,
+and it is the one an error row needs most.
+
+**D4 · The default fold state follows what the row is for.** A statement identifies *which*
+command ran; the reader scanning for the failure does not want it open. An error is *why* they
+opened the log. So a statement row starts folded and an error row renders exactly as it does
+today — wrapped, whole, no fold control — and simply gains the copy button. Rows with no
+`fullDetail` get neither control.
+
+**D5 · A row is foldable when there is more to see.** Two independent causes: the original differs
+from the line (it contained a newline or repeated whitespace), or the line is clamped at its
+current width. The first is a string comparison. The second is a measurement — `scrollWidth >
+clientWidth` on the line element, recomputed from one `ResizeObserver` on the scroll container and
+when the item list changes — and it is what catches a single-line statement too wide for the
+viewport, which the comparison alone would miss. Rows that are not foldable show no chevron and
+do not respond to a click.
+
+**D6 · The chevron is the control.** The row cannot be a `<button>`: it already contains one for
+copy, and nested buttons are invalid. So the fold control is its own `<button>` carrying
+`aria-expanded` and a name of its own ("Show full statement" / "Hide full statement"), the copy
+button is a second, separate tab stop, and the row itself stays a `<div>` with no `role`. The
+chevron's slot is reserved on every command row so the text column stays aligned whether or not a
+given row is foldable.
+
+**D7 · Clicking the row toggles it, except when a selection ends there.** Click-anywhere is what
+makes the affordance usable at 12px, and it is the convention of every CI log. But an unfolded
+statement is text people select and copy by hand, and a naive handler collapses the row on
+mouse-up at the end of a drag. The handler ignores a click when `window.getSelection()` is not
+collapsed, and ignores clicks that originate inside a button. Mouse convenience only — assistive
+technology sees D6's controls.
+
+**D8 · The section's cap rises while a row is open.** A 630px statement inside a 240px box is a
+keyhole. While any row in a section is unfolded, that section's scroll box is capped at
+`max(240px, 60vh)` instead of `ITEM_HEIGHT * MAX_VISIBLE_ITEMS`, and returns to the collapsed cap
+when the last row folds. Both halves matter: `60vh` is the honest unit for "how much of the screen
+may this take", and the `max()` floor keeps a short window from shrinking the box below its
+collapsed height. The box still scrolls — a statement with a few hundred columns is taller than
+any cap worth setting — but it scrolls over most of a screen instead of over ten lines.
+
+**D9 · One scroll context.** The unfolded block never gets its own `overflow` — it grows to its
+natural height and the section scrolls. A scrollbar inside a scrollbar inside a page is not a
+thing the reader can operate at this size.
+
+**D10 · The unfolded block replaces the line.** Same cell, same left edge; `whitespace-pre-wrap
+break-words` on the original text, in the row's mono face, on `bg-background` inside a
+`border-control-border` block. Replacing rather than appending keeps one statement on screen at a
+time and keeps the index, timestamps and status glyph pinned to the row's first line, which
+`items-start` already does.
+
+**D11 · Nothing in the row moves on hover, and the row gets 4px taller.** The copy button occupies
+its slot in the existing right-hand cluster whether or not it is visible, so revealing it shifts
+nothing. It is visible on hover, on focus, while the row is open, and always where hover does not
+exist (`pointer-coarse`). Both slots are reserved on *every* row, including `BEGIN` and
+`Completed`, so one row height holds for the whole list. That height moves from 20px to 24px: the
+smallest `Button` size is `h-6`, and a control that tall would push the row to 28px, so the copy
+button is constrained to `h-5` with a `size-3` icon — 20px of content plus the existing `py-0.5`.
+`ITEM_HEIGHT` moves from 20 to 24 with it, so `MAX_VISIBLE_ITEMS` keeps meaning ten rows and the
+collapsed cap becomes 240px. A 20px target is the floor worth accepting here; anything smaller is
+not clickable, and anything larger costs another 40px of vertical space per ten rows.
+
+**D12 · Strings.** `common.copy`, `common.copied` and `common.copy-failed` already exist and come
+free with `CopyButton`. The fold control needs two new keys under `task-run.log-detail`; they are
+accessible names, not visible labels, and land in `en-US` with the other locales falling back
+until translated.
+
+## States
+
+Mockups A–E are in the PR description. Product typography, spacing and semantic colors are taken
+from the live component.
+
+| | State | What it settles |
+|---|---|---|
+| A | Today | The 80-character cut, for comparison |
+| B | Folded, hover | D2, D3, D5, D6, D11 — the two affordances and the reserved slots |
+| C | Unfolded | D8, D9, D10 — original formatting, raised cap, one scrollbar |
+| D | An error and a statement in one section | D4 — the two default fold states side by side |
+| E | Narrow container | D2 — the same row in the deploy sheet, clamped by its width |
+
+## Scope
+
+Frontend only. The viewer is embedded by `DatabaseChangelogDetailPage`, `RevisionDetailPanel`,
+`DeployTaskRunHistorySheet` and `DeployLatestTaskRunInfo`; all four inherit the change.
+
+| File | Change |
+|---|---|
+| `task-run-log/types.ts` | `fullDetail?: string` on `DisplayItem` |
+| `task-run-log/model.ts` | Delete the `substring`; return both forms from `getEntryDetail` |
+| `task-run-log/SectionContent.tsx` | Fold control, copy button, CSS clamp, overflow measurement, section cap, `ITEM_HEIGHT` 20 → 24 |
+| `locales/en-US.json` | Two accessible names |
+
+Tests, none of which exist today — which is how #21276 passed a clean suite while changing the
+behavior of this function:
+
+- `model.test.ts`: a multi-line statement yields a collapsed `detail` and an untouched
+  `fullDetail`; a statement past 80 characters is not truncated (regression); an error populates
+  both; an entry with no statement yields `"-"` and no `fullDetail`.
+- `SectionContent`: a foldable row toggles and reports `aria-expanded`; copy receives the original
+  text, not the line; the open set resets when `datasetKey` changes, as `showAllItems` already
+  does; an error row renders wrapped with a copy button and no chevron.
+
+## Not in this PR
+
+The implementation, which follows separately. Also deliberately out:
+
+- **Error rows becoming foldable.** They are open by default (D4); a fold control on them is a
+  second decision, worth making only if long errors turn out to crowd the sections they appear in.
+- **Syntax highlighting in the unfolded block.** A Monaco instance per log row is far past what
+  this surface can afford. The statement is mono, preformatted and copyable; the editor is one
+  click away on the pages that embed the viewer.
+- **The other entry types.** `SCHEMA_DUMP`, `DATABASE_SYNC` and friends carry status words, not
+  payloads. They gain `fullDetail` only if they ever carry one.


### PR DESCRIPTION
Design doc for the task-run log viewer: `docs/design/task-run-log-statement-unfold.md`.

The log cuts every executed statement to 80 characters and appends `...`, and it does it inside the model — so by the time a row renders, the statement is no longer in the component tree and nothing downstream can offer to show or copy the rest. For the statements customers actually run (SDL, or a `CREATE TABLE` with a few hundred columns) the row says almost nothing. A failed command is worse: an early return hands back `response.error` before the statement is ever read, so the row that a reader opened the log for shows the driver's complaint and no hint of which SQL produced it — and the error text never names it, because every driver logs a bare `err.Error()`. #21276 finds the truncation and removes it, which is the right diagnosis and a partial fix: the `\s+ → " "` normalization above it stays, so the statement becomes one run-on line, it floods a 200px scroll box, copy is still absent, and the failed row is untouched. The doc lands on one rule: **a row shows one line, and nothing the row is about is destroyed to produce that line.** Frontend-only, inherited by the four surfaces that embed the viewer.

### What the doc decides

- A command row has up to two payloads, and the entry already carries both — the converter hangs `response` on the same entry that holds `Range`/`Statement`. `DisplayItem` gains `statement` and `error` beside `detail`, both verbatim, plus `defaultOpen` — the row the auto-open rule picked. The view cannot derive that one: it sees a section at a time while the pick is made across a whole execution context, and `error` is no substitute, since every transient failed attempt carries one.
- The line is the news: the error when the command failed, the statement when it did not. No length constant survives in the model — the line is clamped by `truncate`, so a wide screen shows more and a narrow sheet shows less, and an error line still wraps whole as it does today.
- Unfolding always reveals the statement, and so does copy — and copy sits beside it, in the row's cluster while the statement is the line and in the unfolded block's corner once it is a block, so position and behavior agree. The error carries no copy button: reaching for an error message in the clipboard is rare next to reaching for the SQL, and it stays selectable text. A row with no recoverable statement gets no copy button rather than one that means something else.
- What unfolds by default says what the row is for. A successful statement starts folded — the reader is scanning. A failed one starts open, with the error as its line and the statement beneath it — but only the failure that explains the outcome: a lock timeout makes the Postgres driver retry the whole command list and re-log every command, so the viewer opens the last failed row and only when nothing after it succeeded — judged across one replica or release file's whole entry sequence rather than within a section, since the retry marker starts a new section and would make every transient failure look terminal, and read from the entries rather than a task-run status two of the four surfaces never pass.
- A row is foldable when unfolding would show something new — the verbatim statement differs from the line it collapsed into, or that line is clamped by the width it was given. Neither test covers the other: a three-line statement can collapse to a line that fits, and a one-liner can be far too wide, which is why the second half is measured with one `ResizeObserver` on the scroll box. A statement that is single-line *and* fits gets no control, because it would unfold to itself. A consequence worth stating: a narrow container turns most rows foldable, and that is honest — at the deploy sheet's width each of them really is hiding text. The ellipsis says which rows are cut; the chevron only says which can open.
- Both controls are shared `Button`s, never native markup — `no-native-control` fails `pnpm --dir frontend check` on a raw `<button>` in feature code. The row stays a `<div>`, so the fold control and copy are siblings rather than nested buttons, and each gets its own tab stop and name.
- Neither control overrides its size. `frontend-ux.md:75-83` forbids replacing a shared control's managed height or resizing its managed icon, and `no-button-dimension-override` enforces it; the smallest shared size is `xs` at 24px. So the row is 28px rather than 20px and `ITEM_HEIGHT` moves 20 → 28, keeping `MAX_VISIBLE_ITEMS` honest at ten rows and a 280px collapsed cap. Dropping to seven rows, or adding a 20px tier to the shared primitive, are both recorded as not taken.
- While a row is open the section is capped at `max(280px, 60vh)`, and the block never gets an `overflow` of its own, so the section's box is the only scroller the viewer owns. The deploy sheet's `SheetBody` is an outer scroller that predates this change; handing it the scroll would cost the viewer a second layout mode, so it is recorded as an option rather than taken.
- The row that opens by default is rendered even when it falls past the 50-entry window a section shows before *Load more*, since otherwise the promise is void in exactly the long migrations where finding the failure by hand is worst — it keeps its real row number rather than its position in the window, and the section scrolls to it, since a row mounted 1,400px below the fold keeps the promise in the DOM and breaks it on the screen.
- The rule holds on a live log, not just a finished one. The viewer polls every five seconds, so a failure followed by the driver's retry marker is never treated as terminal, and open state is derived rather than set at mount — open when marked or when the reader opened it, folded when the reader folded it — so a deploy watched from the plan page opens its failure when it arrives, and a failure the reader folded stays folded — through polls, through collapsing the section around it, and up to the phase boundary, where the status-keyed remount deliberately starts the new phase fresh. Those folds are keyed by the entry's own identity rather than by the row's positional render key, which is renamed under them when a second replica appears or a retry marker splits a section.
- One guard reads the run's status where a caller passes it: a `DONE` run marks nothing. It costs the live behavior nothing and it covers the shape the entries get wrong — CockroachDB's autocommit retry logs one `COMMAND_EXECUTE` and a response per attempt, and the converter keeps the first, so a statement that succeeded on retry is already recorded as a failure today. That row is wrong before this design reaches it, and it is listed as a backend defect rather than papered over here.
- Every column before the statement reserves its width. The relative-time column has none today and is dropped entirely when empty, so `+0ms`, `+12ms` and `+506ms` each shift what follows and the statement starts at three different x positions inside one section — 228px, 235px and 242px, measured. The log has always been ragged this way; ragged text reads as text, but a column of identical chevrons beside it does not. Reserving the column straightens the statement column too, which is the part of the change that improves the log as it stands.
- Tests are listed for both layers; none exist today, which is how #21276 passed a clean suite while changing this function's behavior.

### Mockups

Product typography, spacing and semantic colors are taken from the live component. The 80-character line in A is produced by running the current `model.ts` expression over the same statement.

**A · Today.** The cut lands mid-identifier on rows 2, 3 and 5 and leaves a third of the row empty — the constant cannot see the width it is cutting for. Row 7 failed, and is the error and nothing else. Note the left edge: the statement starts further right on each of the first three rows, because the relative-time column has no reserved width.

<img width="900" height="230" alt="A · Today: the 80-character cut, and a failed row that is error-only" src="https://github.com/user-attachments/assets/49034b23-33c3-4514-ac9a-25080bf11937" />

**B · Folded, with row 2 hovered.** The line now runs to the width it is given, and copy sits in the existing right-hand cluster and shifts nothing when it appears. Against A, the left edge is straight: one x for the fold controls, one for the statements. Rows 1, 4 and 6 carry no chevron — their statements are single-line and fit, so unfolding them would change nothing. Compare E, where the same rows earn one at sheet width.

<img width="900" height="228" alt="B · Folded, with row 2 hovered" src="https://github.com/user-attachments/assets/31155483-c025-4359-8c5a-9750291a3d6c" />

**C · Row 2 unfolded.** Verbatim formatting, in place, one statement at a time; the index, timestamps and glyph stay pinned to the first line, and copy has moved into the block's corner. The section is capped at `max(280px, 60vh)` and still scrolls — a few hundred columns is taller than any cap worth setting.

<img width="900" height="534" alt="C · Row 2 unfolded, with copy in the block's corner" src="https://github.com/user-attachments/assets/646f66a5-f4a1-4140-a0cc-9dd10b08d181" />

**D · A failed command.** The same failure as row 7 of A, under the proposal: the error keeps the line, with no copy button of its own, and the statement it came from sits in the block beneath it — open by default, with the row's only copy button in its corner.

<img width="900" height="239" alt="D · A failed command, with the statement it came from beneath the error" src="https://github.com/user-attachments/assets/ba84285c-45ec-432d-bc7a-d9049373765b" />

**E · The same rows in the deploy sheet.** Nothing about the component changes; the clamp simply resolves against 560px — and every row earns a chevron here, including the two that had none in B, because at this width each of them really is hiding text.

<img width="560" height="170" alt="E · The same rows in the deploy sheet" src="https://github.com/user-attachments/assets/998faf51-c92d-4004-bf94-24d4d4dc3abe" />

### Not in this PR

The implementation, which follows separately. Also out, with reasons in the doc: a smaller shared control size (the 8px the row gains is the cost of the size contract, and a 20px tier is a design-system change), syntax highlighting in the unfolded block (a Monaco instance per log row is far past what this surface can afford), and the entry types that carry status words rather than payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
