### PR TITLE
test: drop testing.Short() guards and run every test in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Bytebase is the standard for database development. Every product and engineering
 
 Test API and workflow behavior against PostgreSQL. Engine dialect and DDL fidelity tests belong in omni.
 
-- Test logic in its owning package. Use `backend/api/v1` for service behavior and `backend/store` for metadata queries, collision isolation, and transaction contention.
+- Test logic in its owning package. Use `backend/api/v1` for service behavior and `backend/store` for metadata queries, collision isolation, and transaction contention. Every test runs in CI, so do not check `testing.Short()` or skip a test to park a known gap.
 - A backend test boots a Bytebase server only when it needs a background runner, real rollout, or audit trail; these tests live in `backend/tests`. Browser E2E tests use the separate frontend harness.
 - Packages needing metadata PostgreSQL use `testcontainer.Main` and `testcontainer.NewMetadataDB`. Target-engine tests use `testcontainer.SharedPgContainer` or its siblings, with `NewPgDatabase` for a database per test. Use these shared fixtures instead of package-owned or per-test containers.
 - Prefer pure functions for handler decisions and conversions. When state reads are necessary, define a narrow interface beside the handler and fake it, as `backend/api/mcp` does with `serverStore`; avoid an interface over the entire store. Every fake requires a contract test against the real store too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Bytebase is the standard for database development. Every product and engineering
 
 Test API and workflow behavior against PostgreSQL. Engine dialect and DDL fidelity tests belong in omni.
 
-- Test logic in its owning package. Use `backend/api/v1` for service behavior and `backend/store` for metadata queries, collision isolation, and transaction contention. Every test runs in CI, so do not check `testing.Short()` or skip a test to park a known gap.
+- Test logic in its owning package. Use `backend/api/v1` for service behavior and `backend/store` for metadata queries, collision isolation, and transaction contention. CI runs every test with no `-short`, so never check `testing.Short()` or skip a test to park a known gap; gate a test on an environment variable only when it needs credentials or a server CI cannot provide.
 - A backend test boots a Bytebase server only when it needs a background runner, real rollout, or audit trail; these tests live in `backend/tests`. Browser E2E tests use the separate frontend harness.
 - Packages needing metadata PostgreSQL use `testcontainer.Main` and `testcontainer.NewMetadataDB`. Target-engine tests use `testcontainer.SharedPgContainer` or its siblings, with `NewPgDatabase` for a database per test. Use these shared fixtures instead of package-owned or per-test containers.
 - Prefer pure functions for handler decisions and conversions. When state reads are necessary, define a narrow interface beside the handler and fake it, as `backend/api/mcp` does with `serverStore`; avoid an interface over the entire store. Every fake requires a contract test against the real store too.

--- a/backend/plugin/advisor/tidb/advisor_statement_dml_dry_run_testcontainer_test.go
+++ b/backend/plugin/advisor/tidb/advisor_statement_dml_dry_run_testcontainer_test.go
@@ -23,9 +23,6 @@ import (
 // in particular that the BATCH DRY RUN and inner-DML SQL derived by text-slicing
 // (omni has no statement-level deparse) execute correctly against TiDB.
 func TestStatementDMLDryRunTiDBContainer(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping TiDB testcontainer test in short mode")
-	}
 	ctx := context.Background()
 	container := testcontainer.GetTestTiDBContainer(ctx, t)
 	defer container.Close(ctx)

--- a/backend/plugin/db/mongodb/mongodb_test.go
+++ b/backend/plugin/db/mongodb/mongodb_test.go
@@ -222,10 +222,6 @@ func TestExecuteLogsParseFailure(t *testing.T) {
 // This ensures the fix for PR #17282 (which changed to single-quote bracket notation
 // for special characters) works correctly.
 func TestQueryWithBracketNotation(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping MongoDB testcontainer test in short mode")
-	}
-
 	ctx := context.Background()
 
 	// Get MongoDB container from testcontainer utility
@@ -332,10 +328,6 @@ func TestQueryWithBracketNotation(t *testing.T) {
 // TestQueryWithBracketNotationStructure tests the exact structure of query results
 // using protocmp to ensure the result format is correct.
 func TestQueryWithBracketNotationStructure(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping MongoDB testcontainer test in short mode")
-	}
-
 	ctx := context.Background()
 
 	// Get MongoDB container from testcontainer utility
@@ -420,10 +412,6 @@ func TestQueryWithBracketNotationStructure(t *testing.T) {
 // large integers must render in mongosh notation (plain decimal), not the Go
 // driver's scientific notation (e.g. 1.779696815227E+12).
 func TestQueryDoubleNotation(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping MongoDB testcontainer test in short mode")
-	}
-
 	ctx := context.Background()
 
 	container := testcontainer.GetTestMongoDBContainer(ctx, t)

--- a/backend/plugin/schema/mysql/sdl_migration_test.go
+++ b/backend/plugin/schema/mysql/sdl_migration_test.go
@@ -389,14 +389,11 @@ func TestLoadCatalogFallbackSeedsExplicitDefaultsForTimestamp(t *testing.T) {
 // skipUnlessLiveOracle gates every live-oracle SDL suite in this package. These
 // suites need the developer's local MySQL oracles (5.7 at 127.0.0.1:13307, 8.0 at
 // 127.0.0.1:13306 — see liveServers) and are opt-in via MYSQL_SDL_LIVE_ORACLE=1.
-// CI runs `go test ./backend/...` without -short and has no such servers, so an
-// explicit environment gate (mirroring the cosmosdb integration tests) keeps the
-// suites out of CI while leaving them one env var away locally.
+// CI has no such servers, so an explicit environment gate (mirroring the cosmosdb
+// integration tests) keeps the suites out of CI while leaving them one env var
+// away locally.
 func skipUnlessLiveOracle(t *testing.T) {
 	t.Helper()
-	if testing.Short() {
-		t.Skip("skipping live MySQL SDL oracle test in short mode")
-	}
 	if os.Getenv("MYSQL_SDL_LIVE_ORACLE") == "" {
 		t.Skip("skipping live MySQL SDL oracle test: set MYSQL_SDL_LIVE_ORACLE=1 (needs local MySQL 5.7 at :13307 and 8.0 at :13306)")
 	}

--- a/backend/store/plan_filter_test.go
+++ b/backend/store/plan_filter_test.go
@@ -16,7 +16,6 @@ func TestGetListPlanFilter(t *testing.T) {
 		wantArgs    []any
 		wantErr     bool
 		errContains string
-		skipTest    bool // Skip tests that require database access
 	}{
 		{
 			name:     "empty filter",
@@ -127,11 +126,11 @@ func TestGetListPlanFilter(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:        "creator filter requires database",
-			filter:      `creator == "users/test@example.com"`,
-			skipTest:    true,
-			wantErr:     false, // Would work with database
-			errContains: "",
+			name:     "creator filter",
+			filter:   `creator == "users/test@example.com"`,
+			wantSQL:  "(plan.creator = $1)",
+			wantArgs: []any{"test@example.com"},
+			wantErr:  false,
 		},
 		{
 			name:        "invalid filter syntax",
@@ -180,10 +179,6 @@ func TestGetListPlanFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if tt.skipTest {
-				t.Skip("Test requires database connection")
-			}
-
 			q, err := GetListPlanFilter(tt.filter)
 
 			if tt.wantErr {


### PR DESCRIPTION
## What changed

- Removed the five `testing.Short()` guards in the repo: the TiDB dry-run container test, the three MongoDB container tests, and the short-mode branch of `skipUnlessLiveOracle` in the MySQL SDL tests.
- `TestGetListPlanFilter` skipped its creator case as "requires database connection", but `GetListPlanFilter` is a pure function. The case now asserts the generated SQL and args, and the `skipTest` field and skip branch are gone.
- Added one sentence to the root `AGENTS.md` test-placement section: every test runs in CI, so do not check `testing.Short()` or skip a test to park a known gap.

## Why

CI runs `go test ./backend/...` with no `-short`, so none of these guards ever fired there. They only hid the container tests from a local `go test -short`, and they suggested a two-tier test policy we do not have. The `AGENTS.md` line makes the actual policy explicit for future contributors and agents.

## Reviewer notes

- The `MYSQL_SDL_LIVE_ORACLE` gate on the MySQL live-oracle suites stays. Those suites need local MySQL 5.7 and 8.0 servers CI does not have, and the schema package's `AGENTS.md` already says that kind of engine conformance belongs in omni.
- The one remaining skipped table case, "Sequence with ownership" in the PostgreSQL definition test, is left in place on purpose. Un-skipping it fails because the generator renders a column-owned non-serial sequence as a bare `bigserial`, dropping its START, INCREMENT, MINVALUE and CACHE settings. That is a generator gap for a separate PR.

## Verification

- `go test` for `backend/plugin/db/mongodb`, `backend/plugin/advisor/tidb`, and `backend/plugin/schema/mysql`, including the container tests that the removed guards used to skip.
- Full `backend/store` suite and the `TestClaim|TestCollision` suite in `backend/tests`, per the pre-PR checklist.
- gofmt, golangci-lint with `--fix` and then clean without it, and the server build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)